### PR TITLE
사용하지 않는 코드 삭제 및 코드 순서 변경

### DIFF
--- a/frontend/src/hooks/useLanguageList.ts
+++ b/frontend/src/hooks/useLanguageList.ts
@@ -1,12 +1,6 @@
-import { Dispatch, SetStateAction } from "react";
 import { useQuery } from "react-query";
 
 import { getLanguageList } from "../apis/reviewer";
-
-export interface FileterLanguageState {
-  filterLanguage: string | null;
-  onSetFilterLanguage: Dispatch<SetStateAction<string | null>>;
-}
 
 const useLanguageList = () => {
   const { data: languages } = useQuery(["getLanguageList"], async () => {

--- a/frontend/src/pages/Main/LanguageList.tsx
+++ b/frontend/src/pages/Main/LanguageList.tsx
@@ -5,10 +5,10 @@ import { Flex, FlexAlignCenter } from "../../components/shared/Flexbox/Flexbox";
 import useLanguageList from "../../hooks/useLanguageList";
 
 interface Props {
-  filterSkills: string[];
-  onSetFilterSkills: Dispatch<SetStateAction<string[]>>;
   filterLanguage: string | null;
+  filterSkills: string[];
   onSetFilterLanguage: Dispatch<SetStateAction<string | null>>;
+  onSetFilterSkills: Dispatch<SetStateAction<string[]>>;
 }
 
 const LanguageList = ({ filterLanguage, filterSkills, onSetFilterLanguage, onSetFilterSkills }: Props) => {


### PR DESCRIPTION
- 사용하지 않는 `interface FileterLanguageState` 코드 삭제
- 언어, 경력 필터 순서 통일되도록 수정