### PR TITLE
JWT 토큰 검증 인터셉터 추가 & 테스트

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
@@ -1,11 +1,23 @@
 package com.wootech.dropthecode.config;
 
+import com.wootech.dropthecode.config.auth.AuthenticationInterceptor;
+import com.wootech.dropthecode.config.auth.GetAuthenticationInterceptor;
+import com.wootech.dropthecode.config.auth.service.AuthService;
+import com.wootech.dropthecode.config.auth.util.JwtTokenProvider;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+    private final AuthService authService;
+
+    public WebMvcConfig(AuthService authService) {
+        this.authService = authService;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -17,5 +29,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .exposedHeaders("*");
 
         WebMvcConfigurer.super.addCorsMappings(registry);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor(authService))
+                .addPathPatterns("/teachers", "/reviews", "/reviews/**");
+        registry.addInterceptor(new GetAuthenticationInterceptor(authService))
+                .addPathPatterns("/reviews/student/**");
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/AuthenticationInterceptor.java
@@ -1,0 +1,40 @@
+package com.wootech.dropthecode.config.auth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.wootech.dropthecode.config.auth.service.AuthService;
+import com.wootech.dropthecode.config.auth.util.AuthorizationExtractor;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+    private final AuthService authService;
+
+    public AuthenticationInterceptor(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (isPreflight(request) || isGet(request)) {
+            return true;
+        }
+        validatesToken(request);
+        return true;
+    }
+
+    protected void validatesToken(HttpServletRequest request) {
+        String accessToken = AuthorizationExtractor.extract(request);
+        authService.validatesAccessToken(accessToken);
+    }
+
+    protected boolean isPreflight(HttpServletRequest request) {
+        return HttpMethod.OPTIONS.matches(request.getMethod());
+    }
+
+    protected boolean isGet(HttpServletRequest request) {
+        return HttpMethod.GET.matches(request.getMethod());
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/GetAuthenticationInterceptor.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/GetAuthenticationInterceptor.java
@@ -1,0 +1,22 @@
+package com.wootech.dropthecode.config.auth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.wootech.dropthecode.config.auth.service.AuthService;
+
+public class GetAuthenticationInterceptor extends AuthenticationInterceptor {
+
+    public GetAuthenticationInterceptor(AuthService authService) {
+        super(authService);
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (isPreflight(request) || !isGet(request)) {
+            return true;
+        }
+        validatesToken(request);
+        return true;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/service/AuthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/service/AuthService.java
@@ -1,0 +1,21 @@
+package com.wootech.dropthecode.config.auth.service;
+
+import com.wootech.dropthecode.config.auth.util.JwtTokenProvider;
+import com.wootech.dropthecode.exception.AuthorizationException;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public void validatesAccessToken(String accessToken) {
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new AuthorizationException("access token이 유효하지 않습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/util/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/util/AuthorizationExtractor.java
@@ -1,0 +1,31 @@
+package com.wootech.dropthecode.config.auth.util;
+
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthorizationExtractor {
+    public static final String AUTHORIZATION = "Authorization";
+    public static String BEARER_TYPE = "Bearer";
+    public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+
+    private AuthorizationExtractor() {
+    }
+
+    public static String extract(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if ((value.toLowerCase().startsWith(BEARER_TYPE.toLowerCase()))) {
+                String authHeaderValue = value.substring(BEARER_TYPE.length()).trim();
+                request.setAttribute(ACCESS_TOKEN_TYPE, value.substring(0, BEARER_TYPE.length()).trim());
+                int commaIndex = authHeaderValue.indexOf(',');
+                if (commaIndex > 0) {
+                    authHeaderValue = authHeaderValue.substring(0, commaIndex);
+                }
+                return authHeaderValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/util/JwtTokenProvider.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/util/JwtTokenProvider.java
@@ -16,9 +16,6 @@ public class JwtTokenProvider {
     @Value("${jwt.token.secret-key:secret-key}")
     private String secretKey;
 
-    private JwtTokenProvider() {
-    }
-
     public String createAccessToken(String payload) {
         return createToken(payload, accessTokenValidityInMilliseconds);
     }

--- a/backend/src/main/java/com/wootech/dropthecode/controller/ReviewController.java
+++ b/backend/src/main/java/com/wootech/dropthecode/controller/ReviewController.java
@@ -35,10 +35,6 @@ public class ReviewController {
      */
     @GetMapping("/student/{id}")
     public ResponseEntity<ReviewsResponse> showStudentReviews(@PathVariable Long id, @RequestHeader HttpHeaders headers) {
-        if (headers.get(HttpHeaders.AUTHORIZATION) == null) {
-            return ResponseEntity.status(401).build();
-        }
-
         ProfileResponse firstTeacher = new ProfileResponse(1L, "user1", "image1");
         ProfileResponse firstStudent = new ProfileResponse(2L, "user2", "image2");
 
@@ -102,10 +98,6 @@ public class ReviewController {
      */
     @PatchMapping("/{id}")
     public ResponseEntity<Void> changeProgress(@PathVariable Long id, @RequestHeader HttpHeaders headers) {
-        if (headers.get(HttpHeaders.AUTHORIZATION) == null) {
-            return ResponseEntity.status(401).build();
-        }
-
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/backend/src/main/java/com/wootech/dropthecode/exception/AuthorizationException.java
+++ b/backend/src/main/java/com/wootech/dropthecode/exception/AuthorizationException.java
@@ -1,0 +1,10 @@
+package com.wootech.dropthecode.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AuthorizationException extends DropTheCodeException {
+
+    public AuthorizationException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/exception/DropTheCodeException.java
+++ b/backend/src/main/java/com/wootech/dropthecode/exception/DropTheCodeException.java
@@ -1,0 +1,16 @@
+package com.wootech.dropthecode.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DropTheCodeException extends RuntimeException {
+    private HttpStatus httpStatus;
+
+    public DropTheCodeException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
@@ -14,9 +14,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<List<ErrorResponse>> handleBindingException(MethodArgumentNotValidException e, BindingResult bindingResult) {
-
         List<ErrorResponse> errorResponses = new ArrayList<>();
 
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
@@ -38,5 +38,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<List<ErrorResponse>> handleMissingParams(MissingServletRequestParameterException e) {
         String name = e.getParameterName() + " parameter is missing";
         return ResponseEntity.badRequest().body(Collections.singletonList(new ErrorResponse(name)));
+    }
+
+    @ExceptionHandler(DropTheCodeException.class)
+    public ResponseEntity<ErrorResponse> dropTheCodeExceptionHandler(DropTheCodeException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ErrorResponse> dropTheCodeExceptionHandler(AuthorizationException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getMessage()));
     }
 }

--- a/backend/src/test/java/com/wootech/dropthecode/config/auth/AuthenticationInterceptorTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/config/auth/AuthenticationInterceptorTest.java
@@ -1,0 +1,282 @@
+package com.wootech.dropthecode.config.auth;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.wootech.dropthecode.config.auth.dto.response.LoginResponse;
+import com.wootech.dropthecode.config.auth.service.AuthService;
+import com.wootech.dropthecode.config.auth.service.OauthService;
+import com.wootech.dropthecode.dto.TechSpec;
+import com.wootech.dropthecode.dto.request.ReviewCreateRequest;
+import com.wootech.dropthecode.dto.request.TeacherRegistrationRequest;
+import com.wootech.dropthecode.exception.AuthorizationException;
+import com.wootech.dropthecode.service.LanguageService;
+import com.wootech.dropthecode.service.TeacherService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthenticationInterceptorTest {
+    private static final String BEARER = "Bearer";
+    private static final String VALID_ACCESS_TOKEN = "valid.access.token";
+    private static final String INVALID_ACCESS_TOKEN = "invalid.access.token";
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private OauthService oauthService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private LanguageService languageService;
+
+    @MockBean
+    private TeacherService teacherService;
+
+    @Nested
+    @DisplayName("인터셉터 거치지 않는 요청 확인")
+    class NoApplyInterceptor {
+
+        @Test
+        @DisplayName("GET /login/oauth")
+        void login() {
+            // given
+            LoginResponse loginResponse = new LoginResponse("air", "air.junseo@gmail.com",
+                    "image url", "access-token", "refresh-token");
+
+            given(oauthService.login(any())).willReturn(loginResponse);
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/login/oauth?providerName=github&code=xxxx")
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("GET /languages")
+        void languages() {
+            // given
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/languages")
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("GET /teachers")
+        void teachers() {
+            // given
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/teachers?language=javascript&career=3&sort=career,desc")
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("GET /reviews/teacher/{id}")
+        void teacherReview() {
+            // given
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/reviews/teacher/1")
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("GET /reviews/{id}")
+        void reviewDetail() {
+            // given
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/reviews/1")
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+    }
+
+    @Nested
+    @DisplayName("인터셉터 거치는 요청 확인")
+    class ApplyInterceptor {
+
+        @Test
+        @DisplayName("POST /teachers")
+        void teachers() {
+            // given
+            doThrow(new AuthorizationException("access token이 유효하지 않습니다."))
+                    .when(authService).validatesAccessToken(INVALID_ACCESS_TOKEN);
+            List<TechSpec> techSpecs = Collections.singletonList(
+                    new TechSpec("java", Arrays.asList("Spring", "Servlet")));
+            TeacherRegistrationRequest request
+                    = new TeacherRegistrationRequest(techSpecs, 3, "백엔드 개발자입니다.", "환영합니다.");
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.post()
+                                                               .uri("/teachers")
+                                                               .header("Authorization", BEARER + INVALID_ACCESS_TOKEN)
+                                                               .body(Mono.just(request), TeacherRegistrationRequest.class)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isUnauthorized();
+        }
+
+        @Test
+        @DisplayName("POST /teachers with token")
+        void teachersWithToken() {
+            // given
+            doNothing().when(authService).validatesAccessToken(VALID_ACCESS_TOKEN);
+            List<TechSpec> techSpecs = Collections.singletonList(
+                    new TechSpec("java", Arrays.asList("Spring", "Servlet")));
+            TeacherRegistrationRequest request
+                    = new TeacherRegistrationRequest(techSpecs, 3, "백엔드 개발자입니다.", "환영합니다.");
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.post()
+                                                               .uri("/teachers")
+                                                               .header("Authorization", BEARER + VALID_ACCESS_TOKEN)
+                                                               .body(Mono.just(request), TeacherRegistrationRequest.class)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isCreated();
+        }
+
+        @Test
+        @DisplayName("POST /reviews")
+        void createReview() {
+            // given
+            doThrow(new AuthorizationException("access token이 유효하지 않습니다."))
+                    .when(authService).validatesAccessToken(INVALID_ACCESS_TOKEN);
+            ReviewCreateRequest reviewCreateRequest =
+                    new ReviewCreateRequest(1L, 2L, "review title", "review content", "pr link");
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.post()
+                                                               .uri("/reviews")
+                                                               .header("Authorization", BEARER + INVALID_ACCESS_TOKEN)
+                                                               .body(Mono.just(reviewCreateRequest), ReviewCreateRequest.class)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isUnauthorized();
+        }
+
+        @Test
+        @DisplayName("POST /reviews with token")
+        void createReviewWithToken() {
+            // given
+            doNothing().when(authService).validatesAccessToken(VALID_ACCESS_TOKEN);
+            ReviewCreateRequest reviewCreateRequest =
+                    new ReviewCreateRequest(1L, 2L, "review title", "review content", "pr link");
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.post()
+                                                               .uri("/reviews")
+                                                               .header("Authorization", BEARER + VALID_ACCESS_TOKEN)
+                                                               .body(Mono.just(reviewCreateRequest), ReviewCreateRequest.class)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isCreated();
+        }
+
+        @Test
+        @DisplayName("GET /reviews/student/{id}")
+        void studentReview() {
+            // given
+            doThrow(new AuthorizationException("access token이 유효하지 않습니다."))
+                    .when(authService).validatesAccessToken(INVALID_ACCESS_TOKEN);
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/reviews/student/1")
+                                                               .header("Authorization", BEARER + INVALID_ACCESS_TOKEN)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isUnauthorized();
+        }
+
+
+        @Test
+        @DisplayName("GET /reviews/student/{id} with token")
+        void studentReviewWithToken() {
+            // given
+            doNothing().when(authService).validatesAccessToken(VALID_ACCESS_TOKEN);
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.get()
+                                                               .uri("/reviews/student/1")
+                                                               .header("Authorization", BEARER + VALID_ACCESS_TOKEN)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("PATCH /reviews/{id}")
+        void updateReview() {
+            // given
+            doThrow(new AuthorizationException("access token이 유효하지 않습니다."))
+                    .when(authService).validatesAccessToken(INVALID_ACCESS_TOKEN);
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.patch()
+                                                               .uri("/reviews/1")
+                                                               .header("Authorization", BEARER + INVALID_ACCESS_TOKEN)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isUnauthorized();
+        }
+
+        @Test
+        @DisplayName("PATCH /reviews/{id} with token")
+        void updateReviewWithToken() {
+            // given
+            doNothing().when(authService).validatesAccessToken(VALID_ACCESS_TOKEN);
+
+            // when
+            WebTestClient.ResponseSpec response = webTestClient.patch()
+                                                               .uri("/reviews/1")
+                                                               .header("Authorization", BEARER + VALID_ACCESS_TOKEN)
+                                                               .exchange();
+
+            // then
+            response.expectStatus().isNoContent();
+        }
+    }
+}

--- a/backend/src/test/java/com/wootech/dropthecode/controller/RestApiDocumentTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/RestApiDocumentTest.java
@@ -1,8 +1,10 @@
 package com.wootech.dropthecode.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootech.dropthecode.config.auth.service.AuthService;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -17,6 +19,9 @@ public abstract class RestApiDocumentTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
 
     protected MockMvc restDocsMockMvc;
     protected MockMvc failRestDocsMockMvc;


### PR DESCRIPTION
Rest docs를 참고하여 JWT 토큰 검증이 필요한 api 요청을 인터셉터를 거치도록 하였습니다.

- 검증을 하지 않는 요청
1) GET /login/oauth
2) GET /languages
3) GET /teachers
4) GET /reviews/teacher/{id}
5) GET/reviews/{id}

- 검증이 필요한 요청 
1) POST /teachers
2) POST /reviews
3) GET /reviews/student/{id}
4) PATCH/reviews/{id}

이 중 /teachers나, /reviews/{id} 같은 경우 HttpMethod만 다르고 검증이 필요한 경우와 필요없는 경우가 둘 다 존재해서 이를 모두 처리해주기 위해 2개의 인터셉터를 만들어서 적용했습니다.

코드리뷰 부탁드립니다!