### PR TITLE
로그인한 유저 정보를 바인딩하는 argumentResolver 추가

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
@@ -1,12 +1,14 @@
 package com.wootech.dropthecode.config;
 
+import java.util.List;
+
 import com.wootech.dropthecode.config.auth.AuthenticationInterceptor;
 import com.wootech.dropthecode.config.auth.GetAuthenticationInterceptor;
+import com.wootech.dropthecode.config.auth.LoginMemberArgumentResolver;
 import com.wootech.dropthecode.config.auth.service.AuthService;
-import com.wootech.dropthecode.config.auth.util.JwtTokenProvider;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -37,5 +39,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/teachers", "/reviews", "/reviews/**");
         registry.addInterceptor(new GetAuthenticationInterceptor(authService))
                 .addPathPatterns("/reviews/student/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver(authService));
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/LoginMemberArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.wootech.dropthecode.config.auth;
 
 import java.util.Objects;
-
 import javax.servlet.http.HttpServletRequest;
 
 import com.wootech.dropthecode.config.auth.domain.Login;

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.wootech.dropthecode.config.auth;
+
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.wootech.dropthecode.config.auth.domain.Login;
+import com.wootech.dropthecode.config.auth.service.AuthService;
+import com.wootech.dropthecode.config.auth.util.AuthorizationExtractor;
+import com.wootech.dropthecode.domain.LoginMember;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthService authService;
+
+    public LoginMemberArgumentResolver(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Login.class)
+                && LoginMember.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken = AuthorizationExtractor
+                .extract(Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)));
+        return authService.findMemberByToken(accessToken);
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/controller/OauthController.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/controller/OauthController.java
@@ -1,8 +1,5 @@
 package com.wootech.dropthecode.config.auth.controller;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-
 import com.wootech.dropthecode.config.auth.dto.request.AuthorizationRequest;
 import com.wootech.dropthecode.config.auth.dto.response.LoginResponse;
 import com.wootech.dropthecode.config.auth.service.OauthService;
@@ -24,18 +21,8 @@ public class OauthController {
      * @title 로그인
      */
     @GetMapping("/login/oauth")
-    public ResponseEntity<LoginResponse> login(@ModelAttribute AuthorizationRequest authorizationRequest,
-                                               HttpServletResponse response) {
+    public ResponseEntity<LoginResponse> login(@ModelAttribute AuthorizationRequest authorizationRequest) {
         LoginResponse loginResponse = oauthService.login(authorizationRequest);
-        response.addCookie(createCookie("refreshToken", loginResponse.getRefreshToken()));
         return ResponseEntity.ok().body(loginResponse);
-    }
-
-    private Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setHttpOnly(true);
-        cookie.setDomain("d1y4kq9j17q5cm.cloudfront.net");
-        cookie.setPath("/");
-        return cookie;
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/domain/Login.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/domain/Login.java
@@ -1,0 +1,11 @@
+package com.wootech.dropthecode.config.auth.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/dto/response/LoginResponse.java
@@ -1,5 +1,7 @@
 package com.wootech.dropthecode.config.auth.dto.response;
 
+import com.wootech.dropthecode.domain.Role;
+
 public class LoginResponse {
     /**
      * 사용자 이름
@@ -17,6 +19,11 @@ public class LoginResponse {
     private String imageUrl;
 
     /**
+     * 선생님 등록 여부(STUDENT, TEACHER)
+     */
+    private Role role;
+
+    /**
      * access token
      */
     private String accessToken;
@@ -29,10 +36,11 @@ public class LoginResponse {
     public LoginResponse() {
     }
 
-    public LoginResponse(String name, String email, String imageUrl, String accessToken, String refreshToken) {
+    public LoginResponse(String name, String email, String imageUrl, Role role, String accessToken, String refreshToken) {
         this.name = name;
         this.email = email;
         this.imageUrl = imageUrl;
+        this.role = role;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }
@@ -47,6 +55,10 @@ public class LoginResponse {
 
     public String getImageUrl() {
         return imageUrl;
+    }
+
+    public Role getRole() {
+        return role;
     }
 
     public String getAccessToken() {

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/dto/response/LoginResponse.java
@@ -1,8 +1,5 @@
 package com.wootech.dropthecode.config.auth.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties("refreshToken")
 public class LoginResponse {
     /**
      * 사용자 이름
@@ -24,6 +21,9 @@ public class LoginResponse {
      */
     private String accessToken;
 
+    /**
+     * refresh token
+     */
     private String refreshToken;
 
     public LoginResponse() {

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/service/AuthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/service/AuthService.java
@@ -1,21 +1,37 @@
 package com.wootech.dropthecode.config.auth.service;
 
 import com.wootech.dropthecode.config.auth.util.JwtTokenProvider;
+import com.wootech.dropthecode.domain.LoginMember;
+import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.exception.AuthorizationException;
+import com.wootech.dropthecode.repository.MemberRepository;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
-    public AuthService(JwtTokenProvider jwtTokenProvider) {
+    public AuthService(JwtTokenProvider jwtTokenProvider, MemberRepository memberRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.memberRepository = memberRepository;
     }
 
     public void validatesAccessToken(String accessToken) {
         if (!jwtTokenProvider.validateToken(accessToken)) {
             throw new AuthorizationException("access token이 유효하지 않습니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public LoginMember findMemberByToken(String accessToken) {
+        Long id = Long.parseLong(jwtTokenProvider.getPayload(accessToken));
+
+        Member member = memberRepository.findById(id)
+                                        .orElseThrow(() -> new AuthorizationException("인증되지 않는 유저입니다."));
+
+        return new LoginMember(member.getId());
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/config/auth/service/OauthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/auth/service/OauthService.java
@@ -53,7 +53,7 @@ public class OauthService {
         // Redis
         // redisUtil.setData(String.valueOf(member.getId()), refreshToken);
 
-        return new LoginResponse(member.getName(), member.getEmail(), member.getImageUrl(), accessToken, refreshToken);
+        return new LoginResponse(member.getName(), member.getEmail(), member.getImageUrl(), member.getRole(), accessToken, refreshToken);
     }
 
     private UserProfile getUserProfile(AuthorizationRequest authorizationRequest, OauthProvider oauthProvider) {

--- a/backend/src/main/java/com/wootech/dropthecode/domain/LoginMember.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/LoginMember.java
@@ -1,0 +1,13 @@
+package com.wootech.dropthecode.domain;
+
+public class LoginMember {
+    private final Long id;
+
+    public LoginMember(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/dto/TechSpec.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/TechSpec.java
@@ -3,7 +3,6 @@ package com.wootech.dropthecode.dto;
 import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 
 public class TechSpec {
 

--- a/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
@@ -44,9 +44,4 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> dropTheCodeExceptionHandler(DropTheCodeException e) {
         return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getMessage()));
     }
-
-    @ExceptionHandler(AuthorizationException.class)
-    public ResponseEntity<ErrorResponse> dropTheCodeExceptionHandler(AuthorizationException e) {
-        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getMessage()));
-    }
 }


### PR DESCRIPTION
토큰 검증이 필요한 요청을 처리하는 컨트롤러에 로그인 한 유저 정보를 바인딩 할 수 있는 argumentResolver를 추가했습니다.

컨트롤러 파라미터 부분에 `@Login LoginMember loginMember` 추가해서 사용.(토큰 검증이 필요한 요청에서만 가능)

사용예시
```java
@PostMapping("/teachers")
public ResponseEntity<Void> registerTeacher(@RequestBody @Valid TeacherRegistrationRequest request, @Login LoginMember loginMember) {
    // ...
    return ResponseEntity.status(HttpStatus.CREATED).build();
}
```