### PR TITLE
z-index 수정

### DIFF
--- a/frontend/src/components/GlobalStyle/GlobalStyle.tsx
+++ b/frontend/src/components/GlobalStyle/GlobalStyle.tsx
@@ -29,13 +29,9 @@ const GlobalStyle = createGlobalStyle`
     cursor: pointer;
   }
 
-  header, a {
-    color: ${COLOR.BLACK};
-    cursor: pointer;
-  }
-
   a {
     display: flex;
+    color: ${COLOR.BLACK};
     text-decoration: none;
   }
 

--- a/frontend/src/components/MenuItemButton/MenuItemButton.tsx
+++ b/frontend/src/components/MenuItemButton/MenuItemButton.tsx
@@ -7,6 +7,8 @@ import { COLOR } from "utils/constants/color";
 
 const Inner = styled.div`
   display: flex;
+  position: relative;
+  z-index: ${({ theme }) => theme.common.zIndex.menuItem};
 `;
 
 const Dimmed = styled.div`
@@ -26,7 +28,7 @@ const Menu = styled.div`
   overflow: auto;
   right: 0;
   padding: 1.875rem;
-  z-index: ${({ theme }) => theme.common.zIndex.menuItem};
+  z-index: 1;
 `;
 
 export interface Props extends Omit<ButtonProps, "active" | "onClick"> {

--- a/frontend/src/components/ModalProvider/Modal.tsx
+++ b/frontend/src/components/ModalProvider/Modal.tsx
@@ -19,6 +19,7 @@ const ModalBlock = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: ${({ theme }) => theme.common.zIndex.modal};
 `;
 
 const Dimmed = styled.div`
@@ -31,10 +32,10 @@ const Dimmed = styled.div`
 `;
 
 const Contents = styled(FlexCenter)`
-  padding: 20px;
+  padding: 1.25rem;
   border-radius: ${({ theme }) => theme.common.shape.rounded};
   background-color: white;
-  z-index: ${({ theme }) => theme.common.zIndex.modal};
+  z-index: 1;
 `;
 
 const Modal = ({ children }: Props) => {

--- a/frontend/src/components/shared/Navigation/Navigation.tsx
+++ b/frontend/src/components/shared/Navigation/Navigation.tsx
@@ -12,6 +12,7 @@ const Inner = styled.header`
   position: fixed;
   top: 0;
   width: 100%;
+  z-index: ${({ theme }) => theme.common.zIndex.header};
 `;
 
 export interface Props {

--- a/frontend/src/types/styled/common.d.ts
+++ b/frontend/src/types/styled/common.d.ts
@@ -6,7 +6,7 @@ export interface Shape {
   circle: string;
 }
 
-export type ZIndex = "modal" | "menuItem";
+export type ZIndex = "menuItem" | "header" | "modal";
 
 export interface Common {
   color: { [key in ThemeColor]: string };

--- a/frontend/src/utils/constants/theme.ts
+++ b/frontend/src/utils/constants/theme.ts
@@ -51,8 +51,9 @@ const common: Common = {
     circle: "100%",
   },
   zIndex: {
-    modal: 99,
-    menuItem: 88,
+    menuItem: 1,
+    header: 10,
+    modal: 20,
   },
 };
 


### PR DESCRIPTION
- Header, Modal, MenuItem의 z-index관계 수정
- theme로 z-index 관리
- Header의 cursor 옵션 제거

- stacking context관련 학습을 진행하고 수정하였으나 position: relative만 부여해도 stacking context가 형성되는 것으로 판단
menuItemButton 컴포넌트의 Inner 스타일컴포넌트에 z-index 부여하고 theme로 관리

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
문서에는 position: relative와 z-index를 같이 부여해야 stacking context가 형성된다고 나와있는데 납득되지 않는다.