### PR TITLE
github oauth id 멤버에 추가

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/util/DataInitializer.java
+++ b/backend/src/main/java/com/wootech/dropthecode/util/DataInitializer.java
@@ -62,7 +62,7 @@ public class DataInitializer implements ApplicationRunner {
         insertLanguageSkill(languageMap, skillMap);
 
         for (long i = 0; i < REPEAT_COUNT; i++) {
-            Map<Long, Member> memberMap = insertMember()
+            Map<Long, Member> memberMap = insertMember(i)
                     .stream()
                     .collect(Collectors.toMap(Member::getId, Function.identity()));
 
@@ -113,7 +113,18 @@ public class DataInitializer implements ApplicationRunner {
         languageSkillRepository.saveAll(languageSkills);
     }
 
-    private List<Member> insertMember() {
+    private List<Member> insertMember(long i) {
+        if (i == 0) {
+            List<Member> members = Arrays.asList(
+                    new Member("56301069", "seed@gmail.com", "Seed", "https://avatars.githubusercontent.com/u/56301069?v=4", Role.TEACHER),
+                    new Member("32974201", "allie@gmail.com", "Allie", "https://avatars.githubusercontent.com/u/32974201?v=4", Role.TEACHER),
+                    new Member("52202474", "bran@gmail.com", "Bran", "https://avatars.githubusercontent.com/u/52202474?v=4", Role.TEACHER),
+                    new Member("45876793", "air@gmail.com", "Air", "https://avatars.githubusercontent.com/u/45876793?v=4", Role.TEACHER),
+                    new Member("50273712", "fafi@gmail.com", "Fafi", "https://avatars.githubusercontent.com/u/50273712?v=44", Role.TEACHER),
+                    new Member("67591151", "shinse@gmail.com", "Shinsehantan", "https://avatars.githubusercontent.com/u/50273712?v=44", Role.TEACHER)
+            );
+            return memberRepository.saveAll(members);
+        }
         List<Member> members = Arrays.asList(
                 new Member("seed@gmail.com", "Seed", "https://avatars.githubusercontent.com/u/56301069?v=4", Role.TEACHER),
                 new Member("allie@gmail.com", "Allie", "https://avatars.githubusercontent.com/u/32974201?v=4", Role.TEACHER),


### PR DESCRIPTION
### 변경사항
* github oauth id를 6개 멤버에만 추가
* github oauth id가 중복인 경우 에러가 발생할 수 있기 때문에 6개 멤버에만 추가