### PR TITLE
리뷰어 등록 페이지 테스트

### DIFF
--- a/frontend/src/__mock__/data/languages.ts
+++ b/frontend/src/__mock__/data/languages.ts
@@ -11,10 +11,6 @@ export const languages: Language[] = [
         id: 1,
         name: "spring",
       },
-      {
-        id: 2,
-        name: "jpa",
-      },
     ],
   },
   {
@@ -24,13 +20,48 @@ export const languages: Language[] = [
     },
     skills: [
       {
-        id: 3,
+        id: 2,
         name: "vue",
       },
       {
-        id: 4,
+        id: 3,
         name: "react",
       },
+      {
+        id: 4,
+        name: "angular",
+      },
     ],
+  },
+  {
+    language: {
+      id: 3,
+      name: "python",
+    },
+    skills: [
+      {
+        id: 5,
+        name: "django",
+      },
+    ],
+  },
+  {
+    language: {
+      id: 4,
+      name: "kotlin",
+    },
+    skills: [
+      {
+        id: 1,
+        name: "spring",
+      },
+    ],
+  },
+  {
+    language: {
+      id: 5,
+      name: "c",
+    },
+    skills: [],
   },
 ];

--- a/frontend/src/pages/ReviewerDetail/ReviewerDetail.test.tsx
+++ b/frontend/src/pages/ReviewerDetail/ReviewerDetail.test.tsx
@@ -39,7 +39,7 @@ describe("리뷰어 상세페이지 테스트", () => {
     expect(reviewContents[0]).toBeInTheDocument();
   });
 
-  it("리뷰어가 나인경우 리뷰 요청하기 버튼이 리뷰 요청 버튼을 클릭할 수 없다 ", async () => {
+  it("리뷰어가 내가 아닌경우 리뷰 요청하기 버튼을 클릭할 수 있다.", async () => {
     mockingToken();
     mockingStudentAuth();
     mockReviewerDetail();
@@ -49,7 +49,7 @@ describe("리뷰어 상세페이지 테스트", () => {
     expect(reviewRequestButton).toBeEnabled();
   });
 
-  it("리뷰어가 내가 아닌경우 리뷰 요청하기 버튼을 클릭할 수 있다 ", async () => {
+  it("리뷰어가 나인경우 리뷰 요청하기 버튼이 리뷰 요청 버튼을 클릭할 수 없다.", async () => {
     mockingToken();
     mockingTeacherAuth();
     mockReviewerDetail();

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -19,17 +19,18 @@ describe("리뷰어 등록 페이지 테스트", () => {
   });
 
   it("언어를 선택한 뒤 언어에 포함되는 기술을 선택할 수 있고, 선택된 버튼이 표시된다.", async () => {
-    const languageButton = await findByText(languages[0].language.name);
-    fireEvent.click(languageButton);
+    const languageButtons = await findAllByText(languages[0].language.name);
+    expect(languageButtons).toHaveLength(1);
+    fireEvent.click(languageButtons[0]);
 
     const skillButton = await findByText(languages[0].skills[0].name);
     expect(skillButton).toBeVisible();
 
-    const selectedLanguageButton = await findAllByText(languages[0].language.name);
-    expect(selectedLanguageButton).toHaveLength(2);
+    const LanguageButtonsAfterSelect = await findAllByText(languages[0].language.name);
+    expect(LanguageButtonsAfterSelect).toHaveLength(2);
 
-    fireEvent.click(selectedLanguageButton[1]);
-    expect(selectedLanguageButton[1]).not.toBeVisible();
+    fireEvent.click(LanguageButtonsAfterSelect[1]);
+    expect(LanguageButtonsAfterSelect[1]).not.toBeVisible();
   });
 
   it("타이틀 입력 입력란에 50자 이상 입력하면 유효성 에러 메시지가 출력된다.", async () => {

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -1,5 +1,4 @@
 import { languages } from "__mock__/data/languages";
-import { mockingToken } from "__mock__/utils/mockingToken";
 import { fireEvent, render, screen } from "__mock__/utils/testUtils";
 
 import ReviewerRegister from "./ReviewerRegister";
@@ -7,7 +6,6 @@ import ReviewerRegister from "./ReviewerRegister";
 const { findByRole, getByRole, findByText, findAllByText } = screen;
 
 beforeEach(() => {
-  mockingToken();
   render(<ReviewerRegister />);
 });
 
@@ -33,7 +31,7 @@ describe("리뷰어 등록 페이지 테스트", () => {
     expect(LanguageButtonsAfterSelect[1]).not.toBeVisible();
   });
 
-  it("타이틀 입력 입력란에 50자 이상 입력하면 유효성 에러 메시지가 출력된다.", async () => {
+  it("타이틀 입력란에 50자 이상 입력하면 유효성 에러 메시지가 출력된다.", async () => {
     const titleInput = await findByRole("textbox", { name: "타이틀" });
     fireEvent.change(titleInput, {
       target: {
@@ -43,6 +41,18 @@ describe("리뷰어 등록 페이지 테스트", () => {
 
     const InvalidationTitleMessage = screen.getByText(/50자 이내로 작성해주세요\./i);
     expect(InvalidationTitleMessage).toBeVisible();
+  });
+
+  it("소개 입력란에 5000자 이상 입력하면 유효성 에러 메시지가 출력된다.", async () => {
+    const contentTextbox = await findByRole("textbox", { name: "소개" });
+    fireEvent.change(contentTextbox, {
+      target: {
+        value: "가".repeat(5001),
+      },
+    });
+
+    const InvalidationContentMessage = screen.getByText(/5000자 이내로 작성해주세요\./i);
+    expect(InvalidationContentMessage).toBeVisible();
   });
 
   it("경력 입력란에 0에서 50이 아닌 숫자를 입력하면 유효성 에러 메시지가 출력된다.", async () => {

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -37,8 +37,7 @@ describe("리뷰어 등록 페이지 테스트", () => {
     const titleInput = await findByRole("textbox", { name: "타이틀" });
     fireEvent.change(titleInput, {
       target: {
-        value:
-          "50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.",
+        value: "가".repeat(51),
       },
     });
 

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -18,7 +18,7 @@ describe("리뷰어 등록 페이지 테스트", () => {
     expect(languageButton).toBeVisible();
   });
 
-  it("언어를 선택한 뒤 언어에 포함되는 기술을 선택할 수 있고, 선택된 버튼이 표시된다.", async () => {
+  it("언어를 선택한 뒤 언어에 포함되는 기술을 선택할 수 있고, 선택된 버튼이 표시된다. 선택된 목록에 있는 버튼을 다시 클릭하면 목록에서 제거된다.", async () => {
     const languageButtons = await findAllByText(languages[0].language.name);
     expect(languageButtons).toHaveLength(1);
     fireEvent.click(languageButtons[0]);

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -12,7 +12,7 @@ beforeEach(() => {
 });
 
 describe("리뷰어 등록 페이지 테스트", () => {
-  it("언어 및 기술 목록을 조회가 끝나면 언어를 선택할 수 있다.", async () => {
+  it("언어 및 기술 목록 조회가 끝나면 언어를 선택할 수 있다.", async () => {
     const languageButton = await findByText(languages[0].language.name);
 
     expect(languageButton).toBeVisible();

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.test.tsx
@@ -1,0 +1,72 @@
+import { languages } from "__mock__/data/languages";
+import { mockingToken } from "__mock__/utils/mockingToken";
+import { fireEvent, render, screen } from "__mock__/utils/testUtils";
+
+import ReviewerRegister from "./ReviewerRegister";
+
+const { findByRole, getByRole, findByText, findAllByText } = screen;
+
+beforeEach(() => {
+  mockingToken();
+  render(<ReviewerRegister />);
+});
+
+describe("리뷰어 등록 페이지 테스트", () => {
+  it("언어 및 기술 목록을 조회가 끝나면 언어를 선택할 수 있다.", async () => {
+    const languageButton = await findByText(languages[0].language.name);
+
+    expect(languageButton).toBeVisible();
+  });
+
+  it("언어를 선택한 뒤 언어에 포함되는 기술을 선택할 수 있고, 선택된 버튼이 표시된다.", async () => {
+    const languageButton = await findByText(languages[0].language.name);
+    fireEvent.click(languageButton);
+
+    const skillButton = await findByText(languages[0].skills[0].name);
+    expect(skillButton).toBeVisible();
+
+    const selectedLanguageButton = await findAllByText(languages[0].language.name);
+    expect(selectedLanguageButton).toHaveLength(2);
+
+    fireEvent.click(selectedLanguageButton[1]);
+    expect(selectedLanguageButton[1]).not.toBeVisible();
+  });
+
+  it("타이틀 입력 입력란에 50자 이상 입력하면 유효성 에러 메시지가 출력된다.", async () => {
+    const titleInput = await findByRole("textbox", { name: "타이틀" });
+    fireEvent.change(titleInput, {
+      target: {
+        value:
+          "50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.50자 넘는 타이틀입니다.",
+      },
+    });
+
+    const InvalidationTitleMessage = screen.getByText(/50자 이내로 작성해주세요\./i);
+    expect(InvalidationTitleMessage).toBeVisible();
+  });
+
+  it("경력 입력란에 0에서 50이 아닌 숫자를 입력하면 유효성 에러 메시지가 출력된다.", async () => {
+    const careerInput = await findByRole("spinbutton", { name: "경력" });
+    fireEvent.change(careerInput, { target: { value: 55 } });
+
+    const inValidCareerMessage = screen.getByText(/0에서 50까지만 입력 가능합니다\./i);
+    expect(inValidCareerMessage).toBeVisible();
+  });
+
+  it("언어 및 기술 선택, 타이틀, 경력, 소개 입력이 모두 유효한 경우 등록 버튼을 누를 수 있다.", async () => {
+    const languageButton = await findByText(languages[0].language.name);
+    const titleInput = await findByRole("textbox", { name: "타이틀" });
+    const careerInput = getByRole("spinbutton", { name: "경력" });
+    const contentTextbox = getByRole("textbox", { name: "소개" });
+    const submitButton = getByRole("button", { name: "등록" });
+
+    fireEvent.click(languageButton);
+    expect(submitButton).toBeDisabled();
+    fireEvent.change(titleInput, { target: { value: "타이틀입니다." } });
+    expect(submitButton).toBeDisabled();
+    fireEvent.change(careerInput, { target: { value: 3 } });
+    expect(submitButton).toBeDisabled();
+    fireEvent.change(contentTextbox, { target: { value: "소개입니다." } });
+    expect(submitButton).toBeEnabled();
+  });
+});


### PR DESCRIPTION
- 언어 및 기술 목록 조회가 끝나면 언어를 선택할 수 있다.
- 언어를 선택한 뒤 언어에 포함되는 기술을 선택할 수 있고, 선택된 버튼이 표시된다.
- 타이틀 입력 입력란에 50자 이상 입력하면 유효성 에러 메시지가 출력된다.
- 경력 입력란에 0에서 50이 아닌 숫자를 입력하면 유효성 에러 메시지가 출력된다.
- 언어 및 기술 선택, 타이틀, 경력, 소개 입력이 모두 유효한 경우 등록 버튼을 누를 수 있다.