### PR TITLE
access token 갱신 요청 인터셉터 거치지 않게 하기

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
@@ -35,7 +35,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(authService))
-                .addPathPatterns("/teachers", "/teachers/me", "/members/me", "/reviews", "/reviews/**", "/token", "/logout");
+                .addPathPatterns("/teachers", "/teachers/me", "/members/me", "/reviews", "/reviews/**", "/logout");
         registry.addInterceptor(new GetAuthenticationInterceptor(authService))
                 .addPathPatterns("/reviews/student/**", "/members/me");
     }


### PR DESCRIPTION
access token 갱신 요청 인터셉터 거치지 않게 하기