### PR TITLE
리뷰어 삭제 없이 유저 삭제를 한 경우 리뷰어 재등록이 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/domain/Member.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/Member.java
@@ -62,6 +62,9 @@ public class Member extends BaseEntity {
     }
 
     public Member update(String email, String name, String imageUrl) {
+        if (this.role == Role.DELETED) {
+            this.role =  Role.STUDENT;
+        }
         this.email = email;
         this.name = name;
         this.imageUrl = imageUrl;

--- a/backend/src/main/java/com/wootech/dropthecode/domain/Member.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/Member.java
@@ -63,7 +63,7 @@ public class Member extends BaseEntity {
 
     public Member update(String email, String name, String imageUrl) {
         if (this.role == Role.DELETED) {
-            this.role =  Role.STUDENT;
+            this.role = Role.STUDENT;
         }
         this.email = email;
         this.name = name;

--- a/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
@@ -83,7 +83,7 @@ public class TeacherProfile {
         sumReviewCount++;
         averageReviewTime = Math.round(newAverageReviewTime * 10) / 10.0;
     }
-    
+
     public void deleteWithMember() {
         this.title = "탈퇴한 사용자입니다.";
         this.content = "내용 없음";

--- a/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
@@ -83,7 +83,7 @@ public class TeacherProfile {
         sumReviewCount++;
         averageReviewTime = Math.round(newAverageReviewTime * 10) / 10.0;
     }
-
+    
     public void deleteWithMember() {
         this.title = "탈퇴한 사용자입니다.";
         this.content = "내용 없음";

--- a/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
@@ -2,9 +2,11 @@ package com.wootech.dropthecode.service;
 
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
+import com.wootech.dropthecode.domain.Role;
 import com.wootech.dropthecode.dto.response.MemberResponse;
 import com.wootech.dropthecode.exception.AuthorizationException;
 import com.wootech.dropthecode.repository.MemberRepository;
+import com.wootech.dropthecode.repository.TeacherProfileRepository;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,12 +21,13 @@ public class MemberService {
     private final TeacherLanguageService teacherLanguageService;
     private final TeacherSkillService teacherSkillService;
     private final MemberRepository memberRepository;
+    private final TeacherProfileRepository teacherProfileRepository;
 
-
-    public MemberService(TeacherLanguageService teacherLanguageService, TeacherSkillService teacherSkillService, MemberRepository memberRepository) {
+    public MemberService(TeacherLanguageService teacherLanguageService, TeacherSkillService teacherSkillService, MemberRepository memberRepository, TeacherProfileRepository teacherProfileRepository) {
         this.teacherLanguageService = teacherLanguageService;
         this.teacherSkillService = teacherSkillService;
         this.memberRepository = memberRepository;
+        this.teacherProfileRepository = teacherProfileRepository;
     }
 
     @Transactional(readOnly = true)
@@ -55,6 +58,10 @@ public class MemberService {
         Member member = findById(loginMember.getId());
         member.delete(DELETED_USER_EMAIL, DELETED_USER_NAME, DELETED_USER_IMAGE_URL);
         save(member);
+
+        if (member.hasRole(Role.TEACHER)) {
+            teacherProfileRepository.delete(member.getTeacherProfile());
+        }
 
         teacherLanguageService.deleteAllWithTeacher(member.getTeacherProfile());
         teacherSkillService.deleteAllWithTeacher(member.getTeacherProfile());


### PR DESCRIPTION
### 오류 상황1
* 리뷰어 삭제 로직 -> 리뷰어 정보를 완전 삭제
* 멤버 삭제 로직 -> 멤버와 리뷰어를 탈퇴된 사용자로 지정

* (리뷰어 삭제 -> 멤버 삭제) 를 하면 리뷰어 정보를 완전 삭제하여 다시 로그인하여도 등록된 리뷰어 정보가 없기 때문에 리뷰어를 등록할 수 있음
* (바로 멤버 삭제)를 하면 리뷰어 정보는 그대로 남아 있어 다시 로그인하면 등록된 리뷰어가 있기 때문에 재등록을 할 수 없음

### 변경 사항1
* 멤버 삭제를 해도 리뷰어 정보는 탈퇴된 사용자로 남기지 않고 리뷰어를 완전 삭제, 멤버는 탈퇴된 멤버로 남김

### 오류 상황2
* 멤버 삭제를 하면 Role을 DELETED 상태로 바꾸는데 재로그인을 해도 DELETED가 유지됨

### 변경 사항2
* 멤버 update를 사용하여 로그인하려는 사용자가 DELETED된 사용자라면 ROLE을 Studnet로 재지정
