### PR TITLE
리뷰 상태 업데이트(ON_GOING -> TEACHER_COMPELTE) NPE 발생

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/dto/request/TeacherRegistrationRequest.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/request/TeacherRegistrationRequest.java
@@ -58,6 +58,7 @@ public class TeacherRegistrationRequest {
                              .title(title)
                              .content(content)
                              .career(career)
+                             .sumReviewCount(0)
                              .member(member)
                              .build();
     }


### PR DESCRIPTION
다음과 같이 `sum_review_count` 컬럼에 기본값을 설정해놓았다.

어떤 값 혹은 NULL 값을 집어 넣으면 0 이 생성되리라 기대했다.

```java
mysql> desc teacher_profile;
+---------------------+--------------+------+-----+---------+-------+
| Field               | Type         | Null | Key | Default | Extra |
+---------------------+--------------+------+-----+---------+-------+
| id                  | bigint(20)   | NO   | PRI | NULL    |       |
| average_review_time | double       | YES  |     | NULL    |       |
| career              | int(11)      | NO   |     | NULL    |       |
| content             | longtext     | NO   |     | NULL    |       |
| created_at          | datetime(6)  | NO   |     | NULL    |       |
| sum_review_count    | int(11)      | YES  |     | 0       |       |
| title               | varchar(255) | NO   |     | NULL    |       |
| updated_at          | datetime(6)  | YES  |     | NULL    |       |
+---------------------+--------------+------+-----+---------+-------+
```

그리고 해당 값에 null 을 집어넣어 보았다.

```java
[Hibernate] 
    insert 
    into
        teacher_profile
        (average_review_time, career, content, created_at, sum_review_count, title, updated_at, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?)
[TRACE] [BasicBinder                             ] : binding parameter [1] as [DOUBLE] - [null]
[TRACE] [BasicBinder                             ] : binding parameter [2] as [INTEGER] - [3]
[TRACE] [BasicBinder                             ] : binding parameter [3] as [CLOB] - [환영합니다.]
[TRACE] [BasicBinder                             ] : binding parameter [4] as [TIMESTAMP] - [2021-08-08T18:47:01.095]
[TRACE] [BasicBinder                             ] : binding parameter [5] as [INTEGER] - [null]
[TRACE] [BasicBinder                             ] : binding parameter [6] as [VARCHAR] - [백엔드 개발자입니다.]
[TRACE] [BasicBinder                             ] : binding parameter [7] as [TIMESTAMP] - [2021-08-08T18:47:01.095]
[TRACE] [BasicBinder                             ] : binding parameter [8] as [BIGINT] - [1]
```

하지만 조회 결과, 0이 아닌 NULL이 삽입되어 있었다.

```java
mysql> select * from teacher_profile where id = 1;
+----+---------------------+--------+------------------+----------------------------+------------------+-------------------------------+----------------------------+
| id | average_review_time | career | content          | created_at                 | sum_review_count | title                         | updated_at                 |
+----+---------------------+--------+------------------+----------------------------+------------------+-------------------------------+----------------------------+
|  1 |                NULL |      3 | 환영합니다.      | 2021-08-08 09:47:01.095000 |             NULL | 백엔드 개발자입니다.          | 2021-08-08 09:47:01.095000 |
+----+---------------------+--------+------------------+----------------------------+------------------+-------------------------------+----------------------------+
```

NULL 값을 직접 넣으면 NULL이 삽입된다. id를 생성할 때처럼 필드에 아예 아무런 값도 넣지 않아야 기본값이 들어간다.

```
/* QUERY 1 */
INSERT INTO simple_table (name) VALUES (NULL)
/* QUERY 2 */
INSERT INTO simple_table (name) VALUES ()
```

- Query 1의 경우 null 값을 explicitly 넣어주었죠. 따라서, NULL인 값을 입력받았다고 생각하기 때문에, 디폴트 값이 생성되지 않는다.
- Query 2의 경우, 아무 것도 입력받지 않는다. `DEFAULT`는 이 때 작동하게 된다. INSERT 할 때 ID를 작성하지 않는 것과 같다.