### PR TITLE
리뷰관련 인수테스트 추가

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/ProfileResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/ProfileResponse.java
@@ -2,8 +2,10 @@ package com.wootech.dropthecode.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProfileResponse {
     /**
      * 프로필 id

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/ReviewResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/ReviewResponse.java
@@ -8,41 +8,43 @@ import com.wootech.dropthecode.util.LocalDateTimeToArray;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ReviewResponse {
     /**
      * 리뷰 id
      */
-    private final Long id;
+    private Long id;
     /**
      * 리뷰 제목
      */
-    private final String title;
+    private String title;
     /**
      * 리뷰 내용
      */
-    private final String content;
+    private String content;
     /**
      * 리뷰 진행 상태
      */
-    private final Progress progress;
+    private Progress progress;
     /**
      * 선생님 프로필
      */
-    private final ProfileResponse teacherProfile;
+    private ProfileResponse teacherProfile;
     /**
      * 학생 프로필
      */
-    private final ProfileResponse studentProfile;
+    private ProfileResponse studentProfile;
     /**
      * PR 링크
      */
-    private final String prUrl;
+    private String prUrl;
     /**
      * 리뷰 생성일
      */
-    private final Integer[] createdAt;
+    private Integer[] createdAt;
 
     @Builder
     public ReviewResponse(Long id, String title, String content, Progress progress, ProfileResponse teacherProfile, ProfileResponse studentProfile, String prUrl, LocalDateTime createdAt) {

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/ReviewsResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/ReviewsResponse.java
@@ -4,18 +4,20 @@ import java.util.List;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ReviewsResponse {
     /**
      * 리뷰 리스트
      */
-    private final List<ReviewResponse> reviews;
+    private List<ReviewResponse> reviews;
 
     /**
      * 전체 페이지 수
      */
-    private final int pageCount;
+    private int pageCount;
 
     @Builder
     public ReviewsResponse(List<ReviewResponse> reviews, int pageCount) {

--- a/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.wootech.dropthecode.service;
 
+import javax.persistence.EntityNotFoundException;
+
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.domain.Role;
@@ -40,7 +42,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findById(Long id) {
         return memberRepository.findById(id)
-                               .orElseThrow(() -> new AuthenticationException("유효하지 않은 유저입니다."));
+                               .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 멤버입니다."));
     }
 
     @Transactional

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
@@ -36,8 +36,14 @@ class AcceptanceTest {
         RestAssured.port = port;
     }
 
-    protected LoginResponse 로그인되어_있음(String name) {
+    protected LoginResponse 학생_로그인되어_있음(String name) {
         ExtractableResponse<Response> response = 로그인_요청(name);
+        return response.as(LoginResponse.class);
+    }
+
+    protected LoginResponse 리뷰어_로그인되어_있음(String name) {
+        ExtractableResponse<Response> response = 로그인_요청(name);
+        // 선생님_등록_요청();
         return response.as(LoginResponse.class);
     }
 

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
@@ -1,13 +1,24 @@
 package com.wootech.dropthecode.acceptance;
 
+import com.wootech.dropthecode.domain.oauth.InMemoryProviderRepository;
+import com.wootech.dropthecode.domain.oauth.OauthProvider;
+import com.wootech.dropthecode.dto.response.LoginResponse;
+import com.wootech.dropthecode.exception.ErrorResponse;
+
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import org.junit.jupiter.api.BeforeEach;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -15,10 +26,46 @@ import io.restassured.RestAssured;
 public class AcceptanceTest {
 
     @LocalServerPort
-    int port;
+    private int port;
+
+    @MockBean
+    protected InMemoryProviderRepository inMemoryProviderRepository;
 
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+    }
+
+    protected LoginResponse 로그인되어_있음() {
+        ExtractableResponse<Response> response = 로그인_요청();
+        return response.as(LoginResponse.class);
+    }
+
+    protected ErrorResponse 예외_결과(ExtractableResponse<Response> response) {
+        return response.as(ErrorResponse.class);
+    }
+
+    protected ExtractableResponse<Response> 로그인_요청() {
+        fakeGithubProviderResponse();
+
+        return RestAssured.given()
+                          .log().all()
+                          .when()
+                          .get("/login/oauth?providerName=github&code=authorizationCode")
+                          .then()
+                          .log().all()
+                          .statusCode(HttpStatus.OK.value())
+                          .extract();
+    }
+
+    private void fakeGithubProviderResponse() {
+        String serverAddress = "http://localhost:" + port;
+        given(inMemoryProviderRepository.findByProviderName("github"))
+                .willReturn(OauthProvider.builder()
+                                         .clientId("fakeClientId")
+                                         .clientSecret("fakeClientSecret")
+                                         .tokenUrl(serverAddress + "/fake/login/oauth/access_token")
+                                         .userInfoUrl(serverAddress + "/fake/user")
+                                         .build());
     }
 }

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.BDDMockito.given;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
-public class AcceptanceTest {
+class AcceptanceTest {
 
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AcceptanceTest.java
@@ -36,8 +36,8 @@ public class AcceptanceTest {
         RestAssured.port = port;
     }
 
-    protected LoginResponse 로그인되어_있음() {
-        ExtractableResponse<Response> response = 로그인_요청();
+    protected LoginResponse 로그인되어_있음(String name) {
+        ExtractableResponse<Response> response = 로그인_요청(name);
         return response.as(LoginResponse.class);
     }
 
@@ -45,8 +45,8 @@ public class AcceptanceTest {
         return response.as(ErrorResponse.class);
     }
 
-    protected ExtractableResponse<Response> 로그인_요청() {
-        fakeGithubProviderResponse();
+    protected ExtractableResponse<Response> 로그인_요청(String name) {
+        fakeGithubProviderResponse(name);
 
         return RestAssured.given()
                           .log().all()
@@ -58,14 +58,14 @@ public class AcceptanceTest {
                           .extract();
     }
 
-    private void fakeGithubProviderResponse() {
+    private void fakeGithubProviderResponse(String name) {
         String serverAddress = "http://localhost:" + port;
         given(inMemoryProviderRepository.findByProviderName("github"))
                 .willReturn(OauthProvider.builder()
                                          .clientId("fakeClientId")
                                          .clientSecret("fakeClientSecret")
                                          .tokenUrl(serverAddress + "/fake/login/oauth/access_token")
-                                         .userInfoUrl(serverAddress + "/fake/user")
+                                         .userInfoUrl(serverAddress + "/fake/user?name=" + name)
                                          .build());
     }
 }

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
@@ -1,14 +1,11 @@
 package com.wootech.dropthecode.acceptance;
 
 import com.wootech.dropthecode.domain.Role;
-import com.wootech.dropthecode.domain.oauth.InMemoryProviderRepository;
-import com.wootech.dropthecode.domain.oauth.OauthProvider;
 import com.wootech.dropthecode.dto.response.AccessTokenResponse;
 import com.wootech.dropthecode.dto.response.LoginResponse;
 import com.wootech.dropthecode.exception.ErrorResponse;
 import com.wootech.dropthecode.exception.OauthTokenRequestException;
 
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +16,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
@@ -31,7 +27,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     void oAuthLoginTestSuccess() {
         // given
         // when
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // then
         assertThat(loginResponse).usingRecursiveComparison().ignoringFields("accessToken", "refreshToken")
@@ -39,8 +35,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                                                          .id(1L)
                                                          .name("air")
                                                          .email("air@email.com")
-                                                         .imageUrl("s3://image")
-                                                         .githubUrl("https://github.com")
+                                                         .imageUrl("s3://image/air")
+                                                         .githubUrl("https://github.com/air")
                                                          .role(Role.STUDENT)
                                                          .tokenType("Bearer")
                                                          .build());
@@ -63,7 +59,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효한 access token & 유효한 refresh token")
     void notExpiredAccessTokenAndNotExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken(), loginResponse.getRefreshToken());
@@ -78,7 +74,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효하지않은 access token & 유효하지않은 refresh token")
     void expiredAccessTokenAndExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken() + "invalid", loginResponse.getRefreshToken() + "invalid");
@@ -93,7 +89,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효한 access token & 유효하지않은 refresh token")
     void notExpiredAccessTokenAndExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken(), loginResponse.getRefreshToken() + "invalid");
@@ -108,7 +104,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효하지않은 access token & 유효한 refresh token")
     void invalidAccessTokenAndNotExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken() + "invalid", loginResponse.getRefreshToken());
@@ -123,7 +119,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그 아웃 성공")
     void logOutSuccess() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 로그아웃_요청(loginResponse.getAccessToken());
@@ -136,7 +132,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그 아웃 실패 - 유효하지 않은 access token")
     void invalidAccessToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음();
+        LoginResponse loginResponse = 로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 로그아웃_요청(loginResponse.getAccessToken() + "invalid");

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
@@ -27,7 +27,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     void oAuthLoginTestSuccess() {
         // given
         // when
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // then
         assertThat(loginResponse).usingRecursiveComparison().ignoringFields("accessToken", "refreshToken")
@@ -59,7 +59,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효한 access token & 유효한 refresh token")
     void notExpiredAccessTokenAndNotExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken(), loginResponse.getRefreshToken());
@@ -74,7 +74,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효하지않은 access token & 유효하지않은 refresh token")
     void expiredAccessTokenAndExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken() + "invalid", loginResponse.getRefreshToken() + "invalid");
@@ -89,7 +89,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효한 access token & 유효하지않은 refresh token")
     void notExpiredAccessTokenAndExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken(), loginResponse.getRefreshToken() + "invalid");
@@ -104,7 +104,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("access token 갱신 - 유효하지않은 access token & 유효한 refresh token")
     void invalidAccessTokenAndNotExpiredRefreshToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 토큰_갱신_요청(loginResponse.getAccessToken() + "invalid", loginResponse.getRefreshToken());
@@ -119,7 +119,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그 아웃 성공")
     void logOutSuccess() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 로그아웃_요청(loginResponse.getAccessToken());
@@ -132,7 +132,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("로그 아웃 실패 - 유효하지 않은 access token")
     void invalidAccessToken() {
         // given
-        LoginResponse loginResponse = 로그인되어_있음("air");
+        LoginResponse loginResponse = 학생_로그인되어_있음("air");
 
         // when
         ExtractableResponse<Response> response = 로그아웃_요청(loginResponse.getAccessToken() + "invalid");

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/AuthAcceptanceTest.java
@@ -26,9 +26,6 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
 @DisplayName("Auth 관련 인수 테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
-    @MockBean
-    private InMemoryProviderRepository inMemoryProviderRepository;
-
     @Test
     @DisplayName("OAuth 로그인 - 로그인 성공")
     void oAuthLoginTestSuccess() {
@@ -148,36 +145,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
         assertThat(error.getErrorMessage()).isEqualTo("access token이 유효하지 않습니다.");
-    }
-
-
-    public LoginResponse 로그인되어_있음() {
-        ExtractableResponse<Response> response = 로그인_요청();
-        return response.as(LoginResponse.class);
-    }
-
-    public ErrorResponse 예외_결과(ExtractableResponse<Response> response) {
-        return response.as(ErrorResponse.class);
-    }
-
-    public ExtractableResponse<Response> 로그인_요청() {
-        String serverAddress = "http://localhost:" + port;
-        given(inMemoryProviderRepository.findByProviderName("github"))
-                .willReturn(OauthProvider.builder()
-                                         .clientId("fakeClientId")
-                                         .clientSecret("fakeClientSecret")
-                                         .tokenUrl(serverAddress + "/fake/login/oauth/access_token")
-                                         .userInfoUrl(serverAddress + "/fake/user")
-                                         .build());
-
-        return RestAssured.given()
-                          .log().all()
-                          .when()
-                          .get("/login/oauth?providerName=github&code=authorizationCode")
-                          .then()
-                          .log().all()
-                          .statusCode(HttpStatus.OK.value())
-                          .extract();
     }
 
     public ExtractableResponse<Response> 유효하지않은_OAUTH_서버_로그인_요청() {

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/FakeGithubController.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/FakeGithubController.java
@@ -7,17 +7,17 @@ import com.wootech.dropthecode.dto.response.OauthTokenResponse;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 @RestController
 public class FakeGithubController {
-    private static final String OAUTH_ID = "1234567";
-    private static final String EMAIL = "air@email.com";
-    private static final String NAME = "air";
-    private static final String IMAGE_URL = "s3://image";
-    private static final String GITHUB_URL = "https://github.com";
+    private static final String OAUTH_ID = "OAuth";
+    private static final String EMAIL = "@email.com";
+    private static final String IMAGE_URL = "s3://image/";
+    private static final String GITHUB_URL = "https://github.com/";
 
     @PostMapping(value = "/fake/login/oauth/access_token", consumes = APPLICATION_FORM_URLENCODED_VALUE)
     public OauthTokenResponse fakeAccessToken() {
@@ -28,13 +28,13 @@ public class FakeGithubController {
     }
 
     @GetMapping(value = "/fake/user")
-    public Map<String, Object> fakeUserInfo() {
+    public Map<String, Object> fakeUserInfo(@RequestParam String name) {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put("id", OAUTH_ID);
-        attributes.put("email", EMAIL);
-        attributes.put("name", NAME);
-        attributes.put("avatar_url", IMAGE_URL);
-        attributes.put("html_url", GITHUB_URL);
+        attributes.put("id", OAUTH_ID + name);
+        attributes.put("email", name + EMAIL);
+        attributes.put("name", name);
+        attributes.put("avatar_url", IMAGE_URL + name);
+        attributes.put("html_url", GITHUB_URL + name);
         return attributes;
     }
 

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -434,8 +434,7 @@ class ReviewAcceptanceTest {
     @Nested
     @DisplayName("리뷰 목록 조회")
     class FindReview extends AcceptanceTest {
-        private String reviewId1;
-        private String reviewId2;
+        private String reviewId;
 
         @Override
         @BeforeEach
@@ -452,22 +451,14 @@ class ReviewAcceptanceTest {
                                                         .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
                                                         .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
                                                         .build();
-            ReviewRequest reviewRequest2 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("코리부!")
-                                                        .content("기대중입니다!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
-            reviewId1 = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest1).header("Location").substring(9);
-            reviewId2 = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest2).header("Location").substring(9);
+            reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest1).header("Location").substring(9);
         }
 
         @Test
         @DisplayName("리뷰 상세 목록 조회 성공")
         void findReviewByIdSuccess() {
             // when
-            ExtractableResponse<Response> response = 리뷰_상세_조회_요청(reviewId1);
+            ExtractableResponse<Response> response = 리뷰_상세_조회_요청(reviewId);
             ReviewResponse result = response.as(ReviewResponse.class);
 
             // then
@@ -497,6 +488,117 @@ class ReviewAcceptanceTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수정")
+    class UpdateReview extends AcceptanceTest {
+        private LoginResponse student;
+        private LoginResponse teacher;
+        private String reviewId;
+
+        @Override
+        @BeforeEach
+        public void setUp() {
+            super.setUp();
+            // given
+            student = 로그인되어_있음("air");
+            teacher = 로그인되어_있음("curry");
+
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+            reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
+        }
+
+        @Test
+        @DisplayName("리뷰 수정 성공")
+        void updateReviewSuccess() {
+            // given
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("[수정] 리뷰 요청합니다!")
+                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 리뷰_수정_요청(reviewId, student.getAccessToken(), reviewRequest);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰인 경우")
+        void notExistReview() {
+            // given
+            String notExistReviewId = "100";
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("[수정] 리뷰 요청합니다!")
+                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 리뷰_수정_요청(notExistReviewId, student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+
+        @Test
+        @DisplayName("로그인 한 멤버와 리뷰의 student가 같지 않은 경우")
+        void noAuthorization() {
+            // given
+            LoginResponse otherStudent = 로그인되어_있음("allie");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("[수정] 리뷰 요청합니다!")
+                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 리뷰_수정_요청(reviewId, otherStudent.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 access token")
+        void invalidAccessToken() {
+            // given
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("[수정] 리뷰 요청합니다!")
+                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청("invalid.access.token", reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
             assertThat(error.getErrorMessage()).isNotNull();
         }
     }
@@ -626,6 +728,19 @@ class ReviewAcceptanceTest {
                           .log().all()
                           .when()
                           .get("/reviews/{id}", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 리뷰_수정_요청(String id, String accessToken, ReviewRequest request) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(request)
+                          .when()
+                          .patch("/reviews/{id}", id)
                           .then()
                           .log().all()
                           .extract();

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -40,13 +40,7 @@ class ReviewAcceptanceTest {
         @DisplayName("리뷰 요청 성공")
         void createReviewSuccess() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -60,13 +54,7 @@ class ReviewAcceptanceTest {
         @DisplayName("student id가 빈 경우")
         void emptyStudentId() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(null)
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(null, teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -82,13 +70,7 @@ class ReviewAcceptanceTest {
         void notExistStudentId() {
             // given
             Long notExistStudentId = 100L;
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(notExistStudentId)
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(notExistStudentId, teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(teacher.getAccessToken(), reviewRequest);
@@ -103,13 +85,7 @@ class ReviewAcceptanceTest {
         @DisplayName("teacher id가 빈 경우")
         void emptyTeacherId() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(null)
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), null);
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -125,13 +101,7 @@ class ReviewAcceptanceTest {
         void notExistTeacherId() {
             // given
             Long notExistTeacherId = 100L;
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(notExistTeacherId)
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), notExistTeacherId);
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -209,13 +179,7 @@ class ReviewAcceptanceTest {
         @DisplayName("유효하지 않은 access token")
         void invalidAccessToken() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청("invalid.access.token", reviewRequest);
@@ -232,13 +196,7 @@ class ReviewAcceptanceTest {
         void studentToStudent() {
             // given
             LoginResponse student2 = 학생_로그인되어_있음("allie");
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(student2.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), student2.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -254,13 +212,7 @@ class ReviewAcceptanceTest {
         @DisplayName("자기 자신에게 리뷰 요청을 보내는 경우")
         void selfRequest() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(student.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), student.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -277,13 +229,7 @@ class ReviewAcceptanceTest {
         void studentNotSameLoginMember() {
             // given
             LoginResponse anonymous = 학생_로그인되어_있음("allie");
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(anonymous.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(anonymous.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
@@ -309,20 +255,9 @@ class ReviewAcceptanceTest {
             student = 학생_로그인되어_있음("air");
             teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest1 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("리뷰 요청합니다!")
-                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
-            ReviewRequest reviewRequest2 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("코리부!")
-                                                        .content("기대중입니다!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
+            ReviewRequest reviewRequest1 = 리뷰_요청_데이터(student.getId(), teacher.getId());
+            ReviewRequest reviewRequest2 = 리뷰_요청_데이터2(student.getId(), teacher.getId());
+
             새로운_리뷰_요청(student.getAccessToken(), reviewRequest1);
             새로운_리뷰_요청(student.getAccessToken(), reviewRequest2);
         }
@@ -383,20 +318,9 @@ class ReviewAcceptanceTest {
             student = 학생_로그인되어_있음("air");
             teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest1 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("리뷰 요청합니다!")
-                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
-            ReviewRequest reviewRequest2 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("코리부!")
-                                                        .content("기대중입니다!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
+            ReviewRequest reviewRequest1 = 리뷰_요청_데이터(student.getId(), teacher.getId());
+            ReviewRequest reviewRequest2 = 리뷰_요청_데이터2(student.getId(), teacher.getId());
+
             새로운_리뷰_요청(student.getAccessToken(), reviewRequest1);
             새로운_리뷰_요청(student.getAccessToken(), reviewRequest2);
         }
@@ -442,16 +366,11 @@ class ReviewAcceptanceTest {
             super.setUp();
             // given
             LoginResponse student = 학생_로그인되어_있음("air");
-            LoginResponse teacher = 학생_로그인되어_있음("curry");
+            LoginResponse teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest1 = ReviewRequest.builder()
-                                                        .studentId(student.getId())
-                                                        .teacherId(teacher.getId())
-                                                        .title("리뷰 요청합니다!")
-                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                        .build();
-            reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest1).header("Location").substring(9);
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
+
+            reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
         }
 
         @Test
@@ -507,13 +426,7 @@ class ReviewAcceptanceTest {
             student = 학생_로그인되어_있음("air");
             teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
             reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
         }
 
@@ -521,13 +434,7 @@ class ReviewAcceptanceTest {
         @DisplayName("리뷰 수정 성공")
         void updateReviewSuccess() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("[수정] 리뷰 요청합니다!")
-                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터2(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 리뷰_수정_요청(reviewId, student.getAccessToken(), reviewRequest);
@@ -541,13 +448,7 @@ class ReviewAcceptanceTest {
         void notExistReview() {
             // given
             String notExistReviewId = "100";
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("[수정] 리뷰 요청합니다!")
-                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터2(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 리뷰_수정_요청(notExistReviewId, student.getAccessToken(), reviewRequest);
@@ -564,13 +465,7 @@ class ReviewAcceptanceTest {
         void noAuthorization() {
             // given
             LoginResponse otherStudent = 학생_로그인되어_있음("allie");
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("[수정] 리뷰 요청합니다!")
-                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터2(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 리뷰_수정_요청(reviewId, otherStudent.getAccessToken(), reviewRequest);
@@ -585,13 +480,7 @@ class ReviewAcceptanceTest {
         @DisplayName("유효하지 않은 access token")
         void invalidAccessToken() {
             // given
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("[수정] 리뷰 요청합니다!")
-                                                       .content("[수정] 초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("[수정] https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터2(student.getId(), teacher.getId());
 
             // when
             ExtractableResponse<Response> response = 리뷰_수정_요청(reviewId, "invalid.access.token", reviewRequest);
@@ -618,13 +507,7 @@ class ReviewAcceptanceTest {
             student = 학생_로그인되어_있음("air");
             teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
             reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
         }
 
@@ -760,13 +643,7 @@ class ReviewAcceptanceTest {
             student = 학생_로그인되어_있음("air");
             teacher = 리뷰어_로그인되어_있음("curry");
 
-            ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student.getId())
-                                                       .teacherId(teacher.getId())
-                                                       .title("리뷰 요청합니다!")
-                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
-                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
-                                                       .build();
+            ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
             reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
         }
 
@@ -1042,5 +919,25 @@ class ReviewAcceptanceTest {
                           .then()
                           .log().all()
                           .extract();
+    }
+
+    public static ReviewRequest 리뷰_요청_데이터(Long studentId, Long teacherId) {
+        return ReviewRequest.builder()
+                            .studentId(studentId)
+                            .teacherId(teacherId)
+                            .title("리뷰 요청합니다!")
+                            .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                            .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                            .build();
+    }
+
+    public static ReviewRequest 리뷰_요청_데이터2(Long studentId, Long teacherId) {
+        return ReviewRequest.builder()
+                            .studentId(studentId)
+                            .teacherId(teacherId)
+                            .title("코리부!")
+                            .content("기대중입니다!")
+                            .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                            .build();
     }
 }

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -2,14 +2,12 @@ package com.wootech.dropthecode.acceptance;
 
 import com.wootech.dropthecode.dto.request.ReviewRequest;
 import com.wootech.dropthecode.dto.response.LoginResponse;
+import com.wootech.dropthecode.dto.response.ReviewsResponse;
 import com.wootech.dropthecode.exception.ErrorResponse;
 
 import org.springframework.http.HttpStatus;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -19,18 +17,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @DisplayName("리뷰 관련 인수 테스트")
-public class ReviewAcceptanceTest {
+class ReviewAcceptanceTest {
 
     @Nested
     @DisplayName("리뷰 생성")
     class CreateReview extends AcceptanceTest {
+        private LoginResponse student;
+        private LoginResponse teacher;
+
+        @Override
+        @BeforeEach
+        public void setUp() {
+            super.setUp();
+            // given
+            student = 로그인되어_있음("air");
+            teacher = 로그인되어_있음("curry");
+        }
 
         @Test
         @DisplayName("리뷰 요청 성공")
         void createReviewSuccess() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -51,8 +58,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("student id가 빈 경우")
         void emptyStudentId() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(null)
                                                        .teacherId(teacher.getId())
@@ -75,7 +80,6 @@ public class ReviewAcceptanceTest {
         void notExistStudentId() {
             // given
             Long notExistStudentId = 100L;
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(notExistStudentId)
                                                        .teacherId(teacher.getId())
@@ -97,7 +101,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("teacher id가 빈 경우")
         void emptyTeacherId() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(null)
@@ -120,7 +123,6 @@ public class ReviewAcceptanceTest {
         void notExistTeacherId() {
             // given
             Long notExistTeacherId = 100L;
-            LoginResponse student = 로그인되어_있음("air");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(notExistTeacherId)
@@ -142,8 +144,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("리뷰 요청 제목인 빈 경우")
         void emptyTitle() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -165,8 +165,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("리뷰 요청 내용이 빈 경우")
         void emptyContent() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -188,8 +186,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("리뷰 요청 pr링크가 빈 경우")
         void emptyPrUrl() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -211,8 +207,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("유효하지 않은 access token")
         void invalidAccessToken() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -235,10 +229,9 @@ public class ReviewAcceptanceTest {
         @DisplayName("학생이 학생에게 리뷰 요청을 보내는 경우")
         void studentToStudent() {
             // given
-            LoginResponse student1 = 로그인되어_있음("air");
             LoginResponse student2 = 로그인되어_있음("allie");
             ReviewRequest reviewRequest = ReviewRequest.builder()
-                                                       .studentId(student1.getId())
+                                                       .studentId(student.getId())
                                                        .teacherId(student2.getId())
                                                        .title("리뷰 요청합니다!")
                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
@@ -246,7 +239,7 @@ public class ReviewAcceptanceTest {
                                                        .build();
 
             // when
-            ExtractableResponse<Response> response = 새로운_리뷰_요청(student1.getAccessToken(), reviewRequest);
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
             ErrorResponse error = 예외_결과(response);
 
             // then
@@ -259,7 +252,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("자기 자신에게 리뷰 요청을 보내는 경우")
         void selfRequest() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(student.getId())
@@ -282,8 +274,6 @@ public class ReviewAcceptanceTest {
         @DisplayName("로그인을 한 멤버와 리뷰 요청인이 다른 경우")
         void studentNotSameLoginMember() {
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
             LoginResponse anonymous = 로그인되어_있음("allie");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(anonymous.getId())
@@ -305,46 +295,75 @@ public class ReviewAcceptanceTest {
 
     @Nested
     @DisplayName("내가 받은 리뷰 목록 조회")
-    class FindStudentReview {
+    class FindStudentReview extends AcceptanceTest {
+        private LoginResponse student;
+        private LoginResponse teacher;
+
+        @Override
+        @BeforeEach
+        public void setUp() {
+            super.setUp();
+            // given
+            student = 로그인되어_있음("air");
+            teacher = 로그인되어_있음("curry");
+
+            ReviewRequest reviewRequest1 = ReviewRequest.builder()
+                                                        .studentId(student.getId())
+                                                        .teacherId(teacher.getId())
+                                                        .title("리뷰 요청합니다!")
+                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                        .build();
+            ReviewRequest reviewRequest2 = ReviewRequest.builder()
+                                                        .studentId(student.getId())
+                                                        .teacherId(teacher.getId())
+                                                        .title("코리부!")
+                                                        .content("기대중입니다!")
+                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                        .build();
+            새로운_리뷰_요청(student.getAccessToken(), reviewRequest1);
+            새로운_리뷰_요청(student.getAccessToken(), reviewRequest2);
+        }
 
         @Test
         @DisplayName("내가 받은 리뷰 목록 조회 성공")
         void findStudentReviewSuccess() {
-            // given
-
             // when
+            ExtractableResponse<Response> response = 내가_받은_리뷰_목록_조회_요청(student.getId(), student.getAccessToken());
+            ReviewsResponse result = response.as(ReviewsResponse.class);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(result.getPageCount()).isEqualTo(1);
+            assertThat(result.getReviews()).hasSize(2);
         }
 
-        @Test
-        @DisplayName("존재하지 않는 학생인 경우")
-        void notExistStudent() {
-            // given
-
-            // when
-
-            // then
-        }
-
+        @Disabled
         @Test
         @DisplayName("로그인 한 유저 id와 받은 리뷰 목록 조희 유저 id가 다른 경우")
-        void findOtherStudentReview() {
+        void showOtherStudentReview() {
             // given
+            Long anonymousMemberId = 100L;
 
             // when
+            ExtractableResponse<Response> response = 내가_받은_리뷰_목록_조회_요청(anonymousMemberId, student.getAccessToken());
+            ErrorResponse result = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            assertThat(result.getErrorMessage()).isNotNull();
         }
 
         @Test
         @DisplayName("유효하지 않은 access token")
         void invalidAccessToken() {
-            // given
-
             // when
+            ExtractableResponse<Response> response = 내가_받은_리뷰_목록_조회_요청(student.getId(), student.getAccessToken() + "invalid");
+            ErrorResponse result = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            assertThat(result.getErrorMessage()).isNotNull();
         }
     }
 
@@ -484,6 +503,10 @@ public class ReviewAcceptanceTest {
         }
     }
 
+    protected ReviewsResponse 내가_받은_리뷰_목록(ExtractableResponse<Response> response) {
+        return response.as(ReviewsResponse.class);
+    }
+
     public static ExtractableResponse<Response> 새로운_리뷰_요청(String accessToken, ReviewRequest request) {
         return RestAssured.given()
                           .log().all()
@@ -492,6 +515,17 @@ public class ReviewAcceptanceTest {
                           .body(request)
                           .when()
                           .post("/reviews")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 내가_받은_리뷰_목록_조회_요청(Long id, String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .when()
+                          .get("/reviews/student/{id}", id)
                           .then()
                           .log().all()
                           .extract();

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -638,12 +638,11 @@ class ReviewAcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         }
 
-        @Disabled
         @Test
         @DisplayName("DENIED인 경우")
         void deniedStatus() {
             // given
-            // 리뷰_거절_요청(reviewId, teacher.getAccessToken());
+            리뷰_거절_요청(reviewId, teacher.getAccessToken());
 
             // when
             ExtractableResponse<Response> response = 리뷰_취소_요청(reviewId, student.getAccessToken());
@@ -654,12 +653,11 @@ class ReviewAcceptanceTest {
             assertThat(error.getErrorMessage()).isNotNull();
         }
 
-        @Disabled
         @Test
         @DisplayName("ON_GOING인 경우")
         void onGoingStatus() {
             // given
-            // 리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
 
             // when
             ExtractableResponse<Response> response = 리뷰_취소_요청(reviewId, student.getAccessToken());
@@ -670,13 +668,13 @@ class ReviewAcceptanceTest {
             assertThat(error.getErrorMessage()).isNotNull();
         }
 
-        @Disabled
+
         @Test
         @DisplayName("TEACHER_COMPLETED인 경우")
         void teacherCompletedStatus() {
             // given
-            // 리뷰_수락_요청(reviewId, teacher.getAccessToken());
-            // 선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
 
             // when
             ExtractableResponse<Response> response = 리뷰_취소_요청(reviewId, student.getAccessToken());
@@ -687,14 +685,13 @@ class ReviewAcceptanceTest {
             assertThat(error.getErrorMessage()).isNotNull();
         }
 
-        @Disabled
         @Test
         @DisplayName("FINISHED인 경우")
         void finishedStatus() {
             // given
-            // 리뷰_수락_요청(reviewId, teacher.getAccessToken());
-            // 선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
-            // 학생_리뷰_완료_요청(reviewId, student.getAccessToken());
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
+            학생_리뷰_완료_요청(reviewId, student.getAccessToken());
 
             // when
             ExtractableResponse<Response> response = 리뷰_취소_요청(reviewId, student.getAccessToken());
@@ -750,87 +747,187 @@ class ReviewAcceptanceTest {
 
     @Nested
     @DisplayName("리뷰 상태 변경")
-    class ChangeReviewProgress {
+    class ChangeReviewProgress extends AcceptanceTest {
+        private LoginResponse student;
+        private LoginResponse teacher;
+        private String reviewId;
 
+        @Override
+        @BeforeEach
+        public void setUp() {
+            super.setUp();
+            // given
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
+
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+            reviewId = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest).header("Location").substring(9);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 리뷰를 DENIED 상태로 변경 성공")
+        void pendingToDenied() {
+            // when
+            ExtractableResponse<Response> response = 리뷰_거절_요청(reviewId, teacher.getAccessToken());
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 리뷰를 ON_GOING 상태로 변경 성공")
+        void pendingToOnGoing() {
+            // when
+            ExtractableResponse<Response> response = 리뷰_수락_요청(reviewId, teacher.getAccessToken());
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Disabled
         @Test
         @DisplayName("ON_GOING 상태의 리뷰를 TEACHER_COMPLETE 상태로 변경 성공")
         void onGoingToTeacherComplete() {
             // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
 
             // when
+            ExtractableResponse<Response> response = 선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         }
 
+        @Disabled
         @Test
         @DisplayName("TEACHER_COMPLETE 상태의 리뷰를 FINISHED 상태로 변경 성공")
         void TeacherCompleteToFinished() {
             // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
 
             // when
+            ExtractableResponse<Response> response = 학생_리뷰_완료_요청(reviewId, student.getAccessToken());
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         }
 
         @Test
-        @DisplayName("존재하지 않은 리뷰인 경우")
-        void notExistReview() {
-            // given
-
+        @DisplayName("선생님이 아닌데 PENDING -> DENIED 변경 요청을 하는 경우")
+        void noTeacherWhenUpdateToDenied() {
             // when
+            ExtractableResponse<Response> response = 리뷰_거절_요청(reviewId, student.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태가 아닌데 PENDING -> DENIED 변경 요청을 하는 경우")
+        void noPendingButUpdateToDenied() {
+            // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+
+            // when
+            ExtractableResponse<Response> response = 리뷰_거절_요청(reviewId, teacher.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("선생님이 아닌데 PENDING -> ON_GOING 변경 요청을 하는 경우")
+        void noTeacherWhenUpdateToOnGoing() {
+            // when
+            ExtractableResponse<Response> response = 리뷰_수락_요청(reviewId, student.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태가 아닌데 PENDING -> ON_GOING 변경 요청을 하는 경우")
+        void noPendingButUpdateToOnGoing() {
+            // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+
+            // when
+            ExtractableResponse<Response> response = 리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
         }
 
         @Test
         @DisplayName("선생님이 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
         void noTeacherWhenUpdateToCompleteReview() {
             // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
 
             // when
+            ExtractableResponse<Response> response = 선생님_리뷰_완료_요청(reviewId, student.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            assertThat(error.getErrorMessage()).isNotNull();
         }
 
         @Test
         @DisplayName("ON_GOING 상태가 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
         void noOnGoingButUpdateToCompleteReview() {
-            // given
-
             // when
+            ExtractableResponse<Response> response = 선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
         }
 
-
+        @Disabled
         @Test
         @DisplayName("학생이 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
         void noStudentWhenUpdateToFinishReview() {
             // given
+            리뷰_수락_요청(reviewId, teacher.getAccessToken());
+            선생님_리뷰_완료_요청(reviewId, teacher.getAccessToken());
 
             // when
+            ExtractableResponse<Response> response = 학생_리뷰_완료_요청(reviewId, teacher.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            assertThat(error.getErrorMessage()).isNotNull();
         }
 
+        @Disabled
         @Test
         @DisplayName("TEACHER_COMPLETE 상태가 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
         void noTeacherCompletedButUpdateToFinishReview() {
-            // given
-
             // when
+            ExtractableResponse<Response> response = 학생_리뷰_완료_요청(reviewId, student.getAccessToken());
+            ErrorResponse error = 예외_결과(response);
 
             // then
-        }
-
-        @Test
-        @DisplayName("유효하지 않은 access token")
-        void invalidAccessToken() {
-            // given
-
-            // when
-
-            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
         }
     }
 
@@ -898,6 +995,50 @@ class ReviewAcceptanceTest {
                           .contentType(APPLICATION_JSON_VALUE)
                           .when()
                           .delete("/reviews/{id}", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 리뷰_거절_요청(String id, String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .when()
+                          .patch("/reviews/{id}/deny", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 리뷰_수락_요청(String id, String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .when()
+                          .patch("/reviews/{id}/accept", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 선생님_리뷰_완료_요청(String id, String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .when()
+                          .patch("/reviews/{id}/complete", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 학생_리뷰_완료_요청(String id, String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .when()
+                          .patch("/reviews/{id}/finish", id)
                           .then()
                           .log().all()
                           .extract();

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -1,285 +1,499 @@
-//package com.wootech.dropthecode.acceptance;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//
-//@DisplayName("리뷰 관련 인수 테스트")
-//public class ReviewAcceptanceTest extends AcceptanceTest {
-//
-//    @Nested
-//    @DisplayName("리뷰 생성")
-//    class CreateReview {
-//
-//        @Test
-//        @DisplayName("리뷰 생성 성공")
-//        void createReviewSuccess() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("student id가 빈 경우")
-//        void emptyStudentId() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("리뷰를 요청한 학생이 존재하지 않는 학생인 경우")
-//        void notExistStudentId() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("teacher id가 빈 경우")
-//        void emptyTeacherId() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("리뷰를 요청받은 선생님이 존재하지 않는 선생님인 경우")
-//        void notExistTeacherId() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("리뷰 요청 제목인 빈 경우")
-//        void emptyTitle() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("리뷰 요청 내용이 빈 경우")
-//        void emptyContent() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("리뷰 요청 pr링크가 빈 경우")
-//        void emptyPrUrl() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("유효하지 않은 access token")
-//        void invalidAccessToken() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("내가 받은 리뷰 목록 조회")
-//    class FindStudentReview {
-//
-//        @Test
-//        @DisplayName("내가 받은 리뷰 목록 조회 성공")
-//        void findStudentReviewSuccess() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 학생인 경우")
-//        void notExistStudent() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("로그인 한 유저 id와 받은 리뷰 목록 조희 유저 id가 다른 경우")
-//        void findOtherStudentReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("유효하지 않은 access token")
-//        void invalidAccessToken() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("내가 리뷰한 리뷰 목록 조회")
-//    class FindTeacherReview {
-//
-//        @Test
-//        @DisplayName("내가 리뷰한 리뷰 목록 조회 성공")
-//        void findTeacherReviewSuccess() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 선생님인 경우")
-//        void notExistTeacher() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("리뷰 목록 조회")
-//    class FindReview {
-//
-//        @Test
-//        @DisplayName("리뷰 상세 목록 조회 성공")
-//        void findReviewByIdSuccess() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 리뷰 상세 목록 조회")
-//        void findReviewByNotExistId() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("리뷰 상태 변경")
-//    class ChangeReviewProgress {
-//
-//        @Test
-//        @DisplayName("ON_GOING 상태의 리뷰를 TEACHER_COMPLETE 상태로 변경 성공")
-//        void onGoingToTeacherComplete() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("TEACHER_COMPLETE 상태의 리뷰를 FINISHED 상태로 변경 성공")
-//        void TeacherCompleteToFinished() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않은 리뷰인 경우")
-//        void notExistReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("선생님이 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
-//        void noTeacherWhenUpdateToCompleteReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("ON_GOING 상태가 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
-//        void noOnGoingButUpdateToCompleteReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//
-//        @Test
-//        @DisplayName("학생이 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
-//        void noStudentWhenUpdateToFinishReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("TEACHER_COMPLETE 상태가 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
-//        void noTeacherCompletedButUpdateToFinishReview() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//
-//        @Test
-//        @DisplayName("유효하지 않은 access token")
-//        void invalidAccessToken() {
-//            // given
-//
-//            // when
-//
-//            // then
-//        }
-//    }
-//}
+package com.wootech.dropthecode.acceptance;
+
+import com.wootech.dropthecode.dto.request.ReviewRequest;
+import com.wootech.dropthecode.dto.response.LoginResponse;
+import com.wootech.dropthecode.exception.ErrorResponse;
+
+import org.springframework.http.HttpStatus;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@DisplayName("리뷰 관련 인수 테스트")
+public class ReviewAcceptanceTest {
+
+    @Nested
+    @DisplayName("리뷰 생성")
+    class CreateReview extends AcceptanceTest {
+
+        @Test
+        @DisplayName("리뷰 요청 성공")
+        void createReviewSuccess() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.header("Location")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("student id가 빈 경우")
+        void emptyStudentId() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(null)
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("리뷰를 요청한 학생이 존재하지 않는 학생인 경우")
+        void notExistStudentId() {
+            // given
+            Long notExistStudentId = 100L;
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(notExistStudentId)
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(teacher.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("teacher id가 빈 경우")
+        void emptyTeacherId() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(null)
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("리뷰를 요청받은 선생님이 존재하지 않는 선생님인 경우")
+        void notExistTeacherId() {
+            // given
+            Long notExistTeacherId = 100L;
+            LoginResponse student = 로그인되어_있음("air");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(notExistTeacherId)
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("리뷰 요청 제목인 빈 경우")
+        void emptyTitle() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title(null)
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("리뷰 요청 내용이 빈 경우")
+        void emptyContent() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content(null)
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("리뷰 요청 pr링크가 빈 경우")
+        void emptyPrUrl() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl(null)
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 access token")
+        void invalidAccessToken() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청("invalid.access.token", reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Disabled
+        @Test
+        @DisplayName("학생이 학생에게 리뷰 요청을 보내는 경우")
+        void studentToStudent() {
+            // given
+            LoginResponse student1 = 로그인되어_있음("air");
+            LoginResponse student2 = 로그인되어_있음("allie");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student1.getId())
+                                                       .teacherId(student2.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student1.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Disabled
+        @Test
+        @DisplayName("자기 자신에게 리뷰 요청을 보내는 경우")
+        void selfRequest() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(student.getId())
+                                                       .teacherId(student.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+
+        @Disabled
+        @Test
+        @DisplayName("로그인을 한 멤버와 리뷰 요청인이 다른 경우")
+        void studentNotSameLoginMember() {
+            // given
+            LoginResponse student = 로그인되어_있음("air");
+            LoginResponse teacher = 로그인되어_있음("curry");
+            LoginResponse anonymous = 로그인되어_있음("allie");
+            ReviewRequest reviewRequest = ReviewRequest.builder()
+                                                       .studentId(anonymous.getId())
+                                                       .teacherId(teacher.getId())
+                                                       .title("리뷰 요청합니다!")
+                                                       .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                       .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                       .build();
+
+            // when
+            ExtractableResponse<Response> response = 새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+            ErrorResponse error = 예외_결과(response);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            assertThat(error.getErrorMessage()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("내가 받은 리뷰 목록 조회")
+    class FindStudentReview {
+
+        @Test
+        @DisplayName("내가 받은 리뷰 목록 조회 성공")
+        void findStudentReviewSuccess() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 학생인 경우")
+        void notExistStudent() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("로그인 한 유저 id와 받은 리뷰 목록 조희 유저 id가 다른 경우")
+        void findOtherStudentReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 access token")
+        void invalidAccessToken() {
+            // given
+
+            // when
+
+            // then
+        }
+    }
+
+    @Nested
+    @DisplayName("내가 리뷰한 리뷰 목록 조회")
+    class FindTeacherReview {
+
+        @Test
+        @DisplayName("내가 리뷰한 리뷰 목록 조회 성공")
+        void findTeacherReviewSuccess() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 선생님인 경우")
+        void notExistTeacher() {
+            // given
+
+            // when
+
+            // then
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 목록 조회")
+    class FindReview {
+
+        @Test
+        @DisplayName("리뷰 상세 목록 조회 성공")
+        void findReviewByIdSuccess() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 상세 목록 조회")
+        void findReviewByNotExistId() {
+            // given
+
+            // when
+
+            // then
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 상태 변경")
+    class ChangeReviewProgress {
+
+        @Test
+        @DisplayName("ON_GOING 상태의 리뷰를 TEACHER_COMPLETE 상태로 변경 성공")
+        void onGoingToTeacherComplete() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("TEACHER_COMPLETE 상태의 리뷰를 FINISHED 상태로 변경 성공")
+        void TeacherCompleteToFinished() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("존재하지 않은 리뷰인 경우")
+        void notExistReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("선생님이 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
+        void noTeacherWhenUpdateToCompleteReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("ON_GOING 상태가 아닌데 ON_GOING -> TEACHER_COMPLETE 변경 요청을 하는 경우")
+        void noOnGoingButUpdateToCompleteReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+
+        @Test
+        @DisplayName("학생이 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
+        void noStudentWhenUpdateToFinishReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("TEACHER_COMPLETE 상태가 아닌데 TEACHER_COMPLETE -> FINISHED 변경 요청을 하는 경우")
+        void noTeacherCompletedButUpdateToFinishReview() {
+            // given
+
+            // when
+
+            // then
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 access token")
+        void invalidAccessToken() {
+            // given
+
+            // when
+
+            // then
+        }
+    }
+
+    public static ExtractableResponse<Response> 새로운_리뷰_요청(String accessToken, ReviewRequest request) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(request)
+                          .when()
+                          .post("/reviews")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -32,8 +32,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            student = 로그인되어_있음("air");
-            teacher = 로그인되어_있음("curry");
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
         }
 
         @Test
@@ -231,7 +231,7 @@ class ReviewAcceptanceTest {
         @DisplayName("학생이 학생에게 리뷰 요청을 보내는 경우")
         void studentToStudent() {
             // given
-            LoginResponse student2 = 로그인되어_있음("allie");
+            LoginResponse student2 = 학생_로그인되어_있음("allie");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(student2.getId())
@@ -276,7 +276,7 @@ class ReviewAcceptanceTest {
         @DisplayName("로그인을 한 멤버와 리뷰 요청인이 다른 경우")
         void studentNotSameLoginMember() {
             // given
-            LoginResponse anonymous = 로그인되어_있음("allie");
+            LoginResponse anonymous = 학생_로그인되어_있음("allie");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(anonymous.getId())
                                                        .teacherId(teacher.getId())
@@ -306,8 +306,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            student = 로그인되어_있음("air");
-            teacher = 로그인되어_있음("curry");
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
 
             ReviewRequest reviewRequest1 = ReviewRequest.builder()
                                                         .studentId(student.getId())
@@ -380,8 +380,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            student = 로그인되어_있음("air");
-            teacher = 로그인되어_있음("curry");
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
 
             ReviewRequest reviewRequest1 = ReviewRequest.builder()
                                                         .studentId(student.getId())
@@ -441,8 +441,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            LoginResponse student = 로그인되어_있음("air");
-            LoginResponse teacher = 로그인되어_있음("curry");
+            LoginResponse student = 학생_로그인되어_있음("air");
+            LoginResponse teacher = 학생_로그인되어_있음("curry");
 
             ReviewRequest reviewRequest1 = ReviewRequest.builder()
                                                         .studentId(student.getId())
@@ -504,8 +504,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            student = 로그인되어_있음("air");
-            teacher = 로그인되어_있음("curry");
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
 
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
@@ -563,7 +563,7 @@ class ReviewAcceptanceTest {
         @DisplayName("로그인 한 멤버와 리뷰의 student가 같지 않은 경우")
         void noAuthorization() {
             // given
-            LoginResponse otherStudent = 로그인되어_있음("allie");
+            LoginResponse otherStudent = 학생_로그인되어_있음("allie");
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
                                                        .teacherId(teacher.getId())
@@ -615,8 +615,8 @@ class ReviewAcceptanceTest {
         public void setUp() {
             super.setUp();
             // given
-            student = 로그인되어_있음("air");
-            teacher = 로그인되어_있음("curry");
+            student = 학생_로그인되어_있음("air");
+            teacher = 리뷰어_로그인되어_있음("curry");
 
             ReviewRequest reviewRequest = ReviewRequest.builder()
                                                        .studentId(student.getId())
@@ -709,7 +709,7 @@ class ReviewAcceptanceTest {
         @DisplayName("로그인 한 멤버와 리뷰의 student가 같지 않은 경우")
         void noAuthorization() {
             // given
-            LoginResponse otherStudent = 로그인되어_있음("allie");
+            LoginResponse otherStudent = 학생_로그인되어_있음("allie");
 
             // when
             ExtractableResponse<Response> response = 리뷰_취소_요청(reviewId, otherStudent.getAccessToken());

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/ReviewAcceptanceTest.java
@@ -369,26 +369,63 @@ class ReviewAcceptanceTest {
 
     @Nested
     @DisplayName("내가 리뷰한 리뷰 목록 조회")
-    class FindTeacherReview {
+    class FindTeacherReview extends AcceptanceTest {
+        private LoginResponse student;
+        private LoginResponse teacher;
+
+        @Override
+        @BeforeEach
+        public void setUp() {
+            super.setUp();
+            // given
+            student = 로그인되어_있음("air");
+            teacher = 로그인되어_있음("curry");
+
+            ReviewRequest reviewRequest1 = ReviewRequest.builder()
+                                                        .studentId(student.getId())
+                                                        .teacherId(teacher.getId())
+                                                        .title("리뷰 요청합니다!")
+                                                        .content("초보라 맞게 한지 잘 모르겠네요.. 잘 부탁드려요!")
+                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                        .build();
+            ReviewRequest reviewRequest2 = ReviewRequest.builder()
+                                                        .studentId(student.getId())
+                                                        .teacherId(teacher.getId())
+                                                        .title("코리부!")
+                                                        .content("기대중입니다!")
+                                                        .prUrl("https://github.com/woowacourse-teams/2021-drop-the-code/pull/262")
+                                                        .build();
+            새로운_리뷰_요청(student.getAccessToken(), reviewRequest1);
+            새로운_리뷰_요청(student.getAccessToken(), reviewRequest2);
+        }
 
         @Test
         @DisplayName("내가 리뷰한 리뷰 목록 조회 성공")
         void findTeacherReviewSuccess() {
-            // given
-
             // when
+            ExtractableResponse<Response> response = 내가_맡은_리뷰_목록_조회_요청(teacher.getId());
+            ReviewsResponse result = response.as(ReviewsResponse.class);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(result.getPageCount()).isEqualTo(1);
+            assertThat(result.getReviews()).hasSize(2);
         }
 
         @Test
         @DisplayName("존재하지 않는 선생님인 경우")
         void notExistTeacher() {
             // given
+            Long notExistTeacherId = 100L;
 
             // when
+            ExtractableResponse<Response> response = 내가_맡은_리뷰_목록_조회_요청(notExistTeacherId);
+            ReviewsResponse result = response.as(ReviewsResponse.class);
 
             // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(result.getPageCount()).isEqualTo(0);
+            assertThat(result.getReviews()).isEmpty();
         }
     }
 
@@ -503,10 +540,6 @@ class ReviewAcceptanceTest {
         }
     }
 
-    protected ReviewsResponse 내가_받은_리뷰_목록(ExtractableResponse<Response> response) {
-        return response.as(ReviewsResponse.class);
-    }
-
     public static ExtractableResponse<Response> 새로운_리뷰_요청(String accessToken, ReviewRequest request) {
         return RestAssured.given()
                           .log().all()
@@ -526,6 +559,16 @@ class ReviewAcceptanceTest {
                           .header("Authorization", "Bearer " + accessToken)
                           .when()
                           .get("/reviews/student/{id}", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 내가_맡은_리뷰_목록_조회_요청(Long id) {
+        return RestAssured.given()
+                          .log().all()
+                          .when()
+                          .get("/reviews/teacher/{id}", id)
                           .then()
                           .log().all()
                           .extract();

--- a/backend/src/test/java/com/wootech/dropthecode/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/service/MemberServiceTest.java
@@ -2,6 +2,8 @@ package com.wootech.dropthecode.service;
 
 import java.util.Optional;
 
+import javax.persistence.EntityNotFoundException;
+
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.domain.Role;
@@ -87,6 +89,6 @@ class MemberServiceTest {
         // when
         // then
         assertThatThrownBy(() -> memberService.findById(id))
-                .isInstanceOf(AuthenticationException.class);
+                .isInstanceOf(EntityNotFoundException.class);
     }
 }


### PR DESCRIPTION
리뷰 관련 인수 테스트 추가했습니다!

---

[인수테스트 구현 도중 발견한 예외 처리되지 않은 내용]

리뷰 생성
- 학생이 학생에게 요청 보낸 경우
- 자기 자신에게 요청 보낸 경우
- 로그인한 사용자와 리뷰의 학생id가 같은지 확인해야함

내가 받은 리뷰 목록 조회
- 로그인한 사용자와 리뷰의 학생id가 같은지 확인해야함

--- 
유의점
- 선생님_등록_요청() 이 구현되어야지 통과하는 테스트들은 @Disabled 처리해놓음
- random port 사용 
  - 이유는 잘 모르겠지만 공식문서에 전체 서버 실행을 원한다면 random port를 쓰는게 좋다고 나와있네요.(https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.testing.spring-boot-applications.with-running-server)