### PR TITLE
styled-normalize 라이브러리 삭제

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,6 @@
         "react-query": "^3.18.1",
         "react-router-dom": "^5.2.0",
         "styled-components": "^5.3.0",
-        "styled-normalize": "^8.0.7",
         "styled-reset": "^4.3.4"
       },
       "devDependencies": {
@@ -31836,14 +31835,6 @@
         "react-is": ">= 16.8.0"
       }
     },
-    "node_modules/styled-normalize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
-      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ==",
-      "peerDependencies": {
-        "styled-components": "^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/styled-reset": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.3.4.tgz",
@@ -59771,12 +59762,6 @@
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       }
-    },
-    "styled-normalize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
-      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ==",
-      "requires": {}
     },
     "styled-reset": {
       "version": "4.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,6 @@
     "react-query": "^3.18.1",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.3.0",
-    "styled-normalize": "^8.0.7",
     "styled-reset": "^4.3.4"
   }
 }

--- a/frontend/src/components/GlobalStyle/GlobalStyle.tsx
+++ b/frontend/src/components/GlobalStyle/GlobalStyle.tsx
@@ -1,11 +1,9 @@
 import { createGlobalStyle } from "styled-components";
-import normalize from "styled-normalize";
 import reset from "styled-reset";
 
 import { COLOR } from "utils/constants/color";
 
 const GlobalStyle = createGlobalStyle`
-  ${normalize}
   ${reset}
 
   @font-face {


### PR DESCRIPTION
- `styled-normalize`는 브라우저마다 다르게 적용되는 스타일을 어느정도 동일한 수준으로 맞춰주는 라이브러리
- `styled-reset`은 스타일을 초기화시키는 라이브러리

결과적으로 `styled-reset`가 적용되기 때문에
중복해서 사용할 필요가 없어 `styled-normalize` 라이브러리 삭제