### PR TITLE
테스트 컨텍스트 캐시 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-core'
     implementation 'com.querydsl:querydsl-jpa'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+
     // querydsl JPAAnnotationProcessor 사용 지정
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:2.2.3"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:1.3.5"
@@ -56,7 +57,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
     // lombok
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'mysql:mysql-connector-java'
@@ -71,7 +72,10 @@ dependencies {
     jsondoclet "capital.scalable:spring-auto-restdocs-json-doclet:2.0.11"
 
     // flyway
-    implementation 'org.flywaydb:flyway-core:'
+    implementation 'org.flywaydb:flyway-core'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 task jsonDoclet(type: Javadoc, dependsOn: compileJava) {

--- a/backend/src/main/java/com/wootech/dropthecode/config/CacheConfig.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/CacheConfig.java
@@ -1,0 +1,54 @@
+package com.wootech.dropthecode.config;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public CacheManager cacheManager() {
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory())
+                .cacheDefaults(redisCacheConfiguration())
+
+                // 수정할 일이 없는 메소드에 사용(언어 및 기술 목록)
+                .withCacheConfiguration("findAllLanguage", redisCacheConfiguration().entryTtl(Duration.ZERO))
+                .withCacheConfiguration("findAllLanguageToMap", redisCacheConfiguration().entryTtl(Duration.ZERO))
+                .withCacheConfiguration("findAllSkillToMap", redisCacheConfiguration().entryTtl(Duration.ZERO))
+                .build();
+    }
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration
+                .defaultCacheConfig(Thread.currentThread().getContextClassLoader())
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new JdkSerializationRedisSerializer()));
+    }
+
+    @Bean
+    public RedisConnectionFactory connectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wootech/dropthecode/exception/GlobalExceptionHandler.java
@@ -13,12 +13,11 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
@@ -78,10 +77,10 @@ public class GlobalExceptionHandler {
     }
 
     private void infoLogging(Exception e) {
-        logger.info(e.getMessage(), e);
+        log.info(e.getMessage(), e);
     }
 
     private void errorLogging(Exception e) {
-        logger.error(e.getMessage(), e);
+        log.error(e.getMessage(), e);
     }
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -18,6 +18,7 @@ spring.flyway.enabled=true
 spring.flyway.baselineOnMigrate = true
 
 spring.cache.type=redis
+spring.redis.host=localhost
 spring.redis.port=3306
 
 jwt.access-token.expire-length=3600000

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -1,11 +1,17 @@
-spring.jpa.hibernate.ddl-auto=create-drop
-
 spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.name=sa
 spring.datasource.password=
+
+spring.jpa.open-in-view=true
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.highlight_sql=true
+spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.redis.host=localhost
 spring.redis.port=6379
 
 jwt.access-token.expire-length=3600000
 jwt.refresh-token.expire-length=72576000
+
+logging.level.org.springframework.test.context.cache=DEBUG

--- a/backend/src/test/java/com/wootech/dropthecode/ControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/ControllerTest.java
@@ -1,0 +1,38 @@
+package com.wootech.dropthecode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootech.dropthecode.service.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class ControllerTest {
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected OauthService oauthService;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected TeacherService teacherService;
+
+    @MockBean
+    protected LanguageService languageService;
+
+    @MockBean
+    protected ReviewService reviewService;
+
+    @MockBean
+    protected FeedbackService feedbackService;
+}

--- a/backend/src/test/java/com/wootech/dropthecode/IntegrationTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/IntegrationTest.java
@@ -1,0 +1,12 @@
+package com.wootech.dropthecode;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public abstract class IntegrationTest {
+
+}

--- a/backend/src/test/java/com/wootech/dropthecode/config/EmbeddedRedisConfig.java
+++ b/backend/src/test/java/com/wootech/dropthecode/config/EmbeddedRedisConfig.java
@@ -11,13 +11,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import redis.embedded.RedisServer;
 
-@Slf4j
 @Profile("test")
 @Configuration
 public class EmbeddedRedisConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbeddedRedisConfig.class);
 
     @Value("${spring.redis.port}")
     private int redisPort;

--- a/backend/src/test/java/com/wootech/dropthecode/config/EmbeddedRedisConfig.java
+++ b/backend/src/test/java/com/wootech/dropthecode/config/EmbeddedRedisConfig.java
@@ -11,8 +11,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.util.StringUtils;
 
+import lombok.extern.slf4j.Slf4j;
 import redis.embedded.RedisServer;
 
+@Slf4j
 @Profile("test")
 @Configuration
 public class EmbeddedRedisConfig {
@@ -81,8 +83,9 @@ public class EmbeddedRedisConfig {
             }
 
         } catch (Exception e) {
+            log.error("EmbeddedRedis 실행 중 에러 발생", e);
         }
 
-        return !StringUtils.isEmpty(pidInfo.toString());
+        return StringUtils.hasText(pidInfo.toString());
     }
 }

--- a/backend/src/test/java/com/wootech/dropthecode/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/AuthControllerTest.java
@@ -6,11 +6,8 @@ import com.wootech.dropthecode.dto.response.AccessTokenResponse;
 import com.wootech.dropthecode.dto.response.LoginResponse;
 import com.wootech.dropthecode.exception.AuthenticationException;
 import com.wootech.dropthecode.exception.OauthTokenRequestException;
-import com.wootech.dropthecode.service.OauthService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.test.web.servlet.ResultActions;
@@ -30,14 +27,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AuthController.class)
 class AuthControllerTest extends RestApiDocumentTest {
 
     @Autowired
     private AuthController authController;
-
-    @MockBean
-    private OauthService oauthService;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/wootech/dropthecode/controller/FeedbackControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/FeedbackControllerTest.java
@@ -7,11 +7,8 @@ import com.wootech.dropthecode.dto.request.FeedbackSearchCondition;
 import com.wootech.dropthecode.dto.response.FeedbackPaginationResponse;
 import com.wootech.dropthecode.dto.response.FeedbackResponse;
 import com.wootech.dropthecode.dto.response.ProfileResponse;
-import com.wootech.dropthecode.service.FeedbackService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 
@@ -27,14 +24,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(FeedbackController.class)
 class FeedbackControllerTest extends RestApiDocumentTest {
 
     @Autowired
     FeedbackController feedbackController;
-
-    @MockBean
-    FeedbackService feedbackService;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/wootech/dropthecode/controller/LanguageControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/LanguageControllerTest.java
@@ -6,11 +6,8 @@ import com.wootech.dropthecode.controller.util.RestDocsMockMvcUtils;
 import com.wootech.dropthecode.dto.response.LanguageResponse;
 import com.wootech.dropthecode.dto.response.LanguageSkillsResponse;
 import com.wootech.dropthecode.dto.response.SkillResponse;
-import com.wootech.dropthecode.service.LanguageService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 
@@ -26,14 +23,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(LanguageController.class)
 class LanguageControllerTest extends RestApiDocumentTest {
 
     @Autowired
     private LanguageController languageController;
-
-    @MockBean
-    private LanguageService languageService;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/wootech/dropthecode/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/MemberControllerTest.java
@@ -13,12 +13,8 @@ import com.wootech.dropthecode.dto.request.TeacherFilterRequest;
 import com.wootech.dropthecode.dto.request.TeacherRegistrationRequest;
 import com.wootech.dropthecode.dto.response.*;
 import com.wootech.dropthecode.exception.TeacherException;
-import com.wootech.dropthecode.service.MemberService;
-import com.wootech.dropthecode.service.TeacherService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.data.util.ClassTypeInformation;
@@ -38,17 +34,10 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(MemberController.class)
 class MemberControllerTest extends RestApiDocumentTest {
 
     @Autowired
     private MemberController memberController;
-
-    @MockBean
-    private TeacherService teacherService;
-
-    @MockBean
-    private MemberService memberService;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/wootech/dropthecode/controller/RestApiDocumentTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/RestApiDocumentTest.java
@@ -1,10 +1,7 @@
 package com.wootech.dropthecode.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wootech.dropthecode.service.AuthService;
+import com.wootech.dropthecode.ControllerTest;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -15,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static capital.scalable.restdocs.misc.AuthorizationSnippet.documentAuthorization;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-public abstract class RestApiDocumentTest {
+public abstract class RestApiDocumentTest extends ControllerTest {
     protected static final String CODE = "XfWjrPh7lFumDNFpd3K5";
     protected static final String GITHUB = "github";
     protected static final String NAME = "air";
@@ -27,12 +24,6 @@ public abstract class RestApiDocumentTest {
     protected static final String ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     protected static final String REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     protected static final String NEW_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2IiwiaWF0IjoxNjI2OTIyNjkyLCJleHAiOjE2MjY5MjYyOTJ9.dsb5uqMS__VcYToB8QrQFVGOkONeDtMyMv4tMXTUuhY";
-
-    @Autowired
-    protected ObjectMapper objectMapper;
-
-    @MockBean
-    protected AuthService authService;
 
     protected MockMvc restDocsMockMvc;
     protected MockMvc failRestDocsMockMvc;

--- a/backend/src/test/java/com/wootech/dropthecode/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/ReviewControllerTest.java
@@ -17,11 +17,8 @@ import com.wootech.dropthecode.exception.AuthenticationException;
 import com.wootech.dropthecode.exception.AuthorizationException;
 import com.wootech.dropthecode.exception.GlobalExceptionHandler;
 import com.wootech.dropthecode.exception.ReviewException;
-import com.wootech.dropthecode.service.ReviewService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -51,14 +48,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ReviewController.class)
 class ReviewControllerTest extends RestApiDocumentTest {
 
     @Autowired
     private ReviewController reviewController;
-
-    @MockBean
-    private ReviewService reviewService;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {

--- a/backend/src/test/java/com/wootech/dropthecode/controller/auth/AuthenticationInterceptorTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/auth/AuthenticationInterceptorTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.wootech.dropthecode.ControllerTest;
 import com.wootech.dropthecode.domain.Role;
 import com.wootech.dropthecode.dto.TechSpec;
 import com.wootech.dropthecode.dto.request.FeedbackRequest;
@@ -14,13 +15,9 @@ import com.wootech.dropthecode.dto.response.LoginResponse;
 import com.wootech.dropthecode.dto.response.MemberResponse;
 import com.wootech.dropthecode.dto.response.ReviewResponse;
 import com.wootech.dropthecode.exception.AuthenticationException;
-import com.wootech.dropthecode.service.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import org.junit.jupiter.api.DisplayName;
@@ -36,9 +33,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.web.reactive.function.BodyInserters.fromFormData;
 
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class AuthenticationInterceptorTest {
+class AuthenticationInterceptorTest extends ControllerTest {
     private static final String BEARER = "Bearer ";
     private static final String VALID_ACCESS_TOKEN = "valid.access.token";
     private static final String INVALID_ACCESS_TOKEN = "invalid.access.token";
@@ -46,24 +41,6 @@ class AuthenticationInterceptorTest {
 
     @Autowired
     private WebTestClient webTestClient;
-
-    @MockBean
-    private OauthService oauthService;
-
-    @MockBean
-    private AuthService authService;
-
-    @MockBean
-    private LanguageService languageService;
-
-    @MockBean
-    private TeacherService teacherService;
-
-    @MockBean
-    private MemberService memberService;
-
-    @MockBean
-    private ReviewService reviewService;
 
     @Nested
     @DisplayName("인터셉터 거치지 않는 요청 확인")

--- a/backend/src/test/java/com/wootech/dropthecode/integration/review/ReviewServiceIntegrationTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/integration/review/ReviewServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.wootech.dropthecode.integration.review;
 
 import java.util.Optional;
 
+import com.wootech.dropthecode.IntegrationTest;
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.domain.Progress;
@@ -16,8 +17,6 @@ import com.wootech.dropthecode.service.ReviewService;
 import com.wootech.dropthecode.util.DatabaseCleanup;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,9 +29,7 @@ import static com.wootech.dropthecode.builder.ReviewBuilder.dummyReview;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@ActiveProfiles("test")
-class ReviewServiceIntegrationTest {
+class ReviewServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
     private ReviewService reviewService;


### PR DESCRIPTION
다음 클래스에서 어플리케이션 컨텍스트가 다시 로드된다.

- AuthenticationInterceptorTest
- MemberAcceptanceTest
- MemberControllerTest
- AuthControllerTest
- LanguageControllerTest
- ReviewControllerTest
- FeedbackControllerTest
- ReviewServiceIntegrationTest
- ReviewRepositoryCustomImplTest

어플리케이션 컨텍스트를 다시 로드하는 것을 다음 클래스로 한정하였다.

기존 9회 어플리케이션 컨텍스트를 로드하는 것에서 4회로 줄여,  테스트 시간을 단축시켰다.

- MemberAcceptanceTest
- MemberControllerTest
- ReviewServiceIntegrationTest
- ReviewRepositoryCustomImplTest


더 자세히 알아보려면 [노션](https://wary-coat-6c2.notion.site/7ce0c795b59d4016850768dfe0a47622)을 참고 바람.