### PR TITLE
엔티티 저장 시 Auditing이 적용안되도록 수정

### DIFF
--- a/backend/src/test/java/com/wootech/dropthecode/repository/ReviewRepositoryCustomImplTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/repository/ReviewRepositoryCustomImplTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
+import com.wootech.dropthecode.config.JpaConfig;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.domain.Progress;
 import com.wootech.dropthecode.domain.Role;
@@ -15,17 +16,16 @@ import com.wootech.dropthecode.dto.ReviewSummary;
 import com.wootech.dropthecode.dto.request.ReviewSearchCondition;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,12 +36,10 @@ import static com.wootech.dropthecode.builder.MemberBuilder.dummyMember;
 import static com.wootech.dropthecode.builder.ReviewBuilder.dummyReview;
 import static com.wootech.dropthecode.builder.TeacherProfileBuilder.dummyTeacherProfile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@Transactional
-@AutoConfigureTestEntityManager
+@Import(JpaConfig.class)
+@DataJpaTest
 class ReviewRepositoryCustomImplTest {
 
     @Autowired

--- a/backend/src/test/java/com/wootech/dropthecode/repository/ReviewRepositoryCustomImplTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/repository/ReviewRepositoryCustomImplTest.java
@@ -15,13 +15,17 @@ import com.wootech.dropthecode.dto.ReviewSummary;
 import com.wootech.dropthecode.dto.request.ReviewSearchCondition;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,9 +36,12 @@ import static com.wootech.dropthecode.builder.MemberBuilder.dummyMember;
 import static com.wootech.dropthecode.builder.ReviewBuilder.dummyReview;
 import static com.wootech.dropthecode.builder.TeacherProfileBuilder.dummyTeacherProfile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@DataJpaTest
 @ActiveProfiles("test")
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Transactional
+@AutoConfigureTestEntityManager
 class ReviewRepositoryCustomImplTest {
 
     @Autowired
@@ -42,6 +49,9 @@ class ReviewRepositoryCustomImplTest {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @MockBean
+    private AuditingEntityListener auditingEntityListener;
 
     private Member airTe;
     private Member allieTe;
@@ -62,6 +72,7 @@ class ReviewRepositoryCustomImplTest {
 
     @BeforeEach
     void setUp() {
+
         // given
         airTe = dummyMember("oauth1", "email1@gmail.com", "name1", "s3://imageUrl1",
                 "github url1", Role.TEACHER, LocalDateTime.now());


### PR DESCRIPTION
# AuditingEntityListener

현재 `ReviewRepositoryCustomImplTest` 클래스에서 랜덤으로 테스트가 실패하고 있다.

테스트가 실패하는 이유는 엔티티에 생성 시각 및 수정 시각을 자동으로 생성하는 `AuditingEntityListener` 가 적용되어, 우리가 설정해놓은 생성 시각 및 수정 시각이 삽입되지 않기 때문이다.

`setUp()` 에서 다음과 같이 오늘 날짜에 `+1` 한 날짜를 생성 시각으로 설정했다.

```java
allieSeed1 = dummyReview(allieTe, 
		seedStu, 
		"review title2", 
		"review content2", 
		"prUrl2",
    4L, 
		Progress.FINISHED, 
		LocalDateTime.now().plusDays(1L) // 생성 시각
);
```

오늘 날짜가 9/5 이므로, 생성 시각은 9/6 이 되어야 한다.

하지만 디버깅을 해보면 9/5로 생성되어있다.

![스크린샷 2021-09-05 오후 9 36 24](https://user-images.githubusercontent.com/56301069/132129742-591a7cdb-f005-4ebe-8ea9-f02d90112ba7.png)

### `@DataJpaTest` 가 자동으로 `AuditingEntityListener` 를 적용하는 것일까?

아니다. 왜냐하면  `Auditing` 은 전체 테스트를 돌렸을 때만 적용되기 때문이다.  `ReviewRepositoryCustomImplTest` 클래스만을 테스트한다면 `Auditing` 이 적용되지 않는다. 즉 `@DataJpaTest` 는 `AuditingEntityListner` 를 적용하지 않는다.

그러면 어째서 전체 테스트를 돌리면 Auditing이 적용되지만, 단일 테스트를 돌리면 적용되지 않을까?

### `AuditingEntityListener` 는 다른 테스트에서 한 번이라도 `@SpringBootTest` 를 이용하여, 해당 객체를 초기화하면 모든 테스트에 적용된다.

SessionFactory는 EntityManager를 생성하는 하이버네이트의 구현체라고 생각하면 된다. 이 SessionFactory의 특징은 어플리케이션 내에서 한 번만 생성되며, 싱글톤으로 모든 곳에서 공유된다는 점이다. EntityManager는 반대로 싱글톤이 아니며, 어플리케이션에서 요청 시 마다 생성된다.

이 SessionFactory가 `Auditing` 하고 무슨 연관이 있을까?

SessionFactory는 싱글톤이므로 한 번 초기화하면 모든 곳에서 공유된다. 그러므로 이전 테스트에서 `@SpringBootTest` 로 설정한 `AuditingEntityListener`가 SessionFactory에 남아 있어서 모든 테스트에서 `Auditing` 이 적용되는 것이다.

그 증거로 `ReviewRepositoryCustomImplTest` 사전에 실행되는 `@SpringBootTest` 클래스들을 모두 삭제하고 전체 테스트를 실행하면 테스트는 정상적으로 수행된다. 즉 Auditing이 적용안되는 것이다.

내부 코드를 확인해보면 더 자세히 알 수 있다.

다음은 SessionFactory를 초기화하는 내부 코드이다. 아래의 `prepare` 메소드를 타고 들어가면 AuditingEntityListener를 생성하는 것을 스택에서 확인할 수 있다.

```java
@Override
public void initSessionFactory(SessionFactoryImplementor sessionFactory) {
	...

	eventListenerRegistry.prepare( this );

	...
}
```

```java
setAuditingHandler:74, AuditingEntityListener (org.springframework.data.jpa.domain.support)
...
<init>:62, AuditingEntityListener (org.springframework.data.jpa.domain.support)
...
prepare:147, EventListenerRegistryImpl (org.hibernate.event.service.internal)
initSessionFactory:379, MetadataImpl (org.hibernate.boot.internal)
<init>:214, SessionFactoryImpl (org.hibernate.internal)
```

그래서 `ReviewRepositoryCustomImplTest` 클래스에서 `AuditingEntityListener` 가 적용되지 않게 해당 빈을 Mock으로 변경해야 한다. `(AuditingEntityListener` 를 Disable 하는 설정을 찾아보았지만 발견하지 못했다.)

하지만 현재 테스트에서는 변경할 수 없다. 왜냐하면 `ReviewRepositoryCustomImplTest` 클래스가 `@DataJpaTest` 이기 때문이다. `@DataJpaTest` 는 어플리케이션 컨텍스트에서 `AuditingEntityListener` 를 빈으로 가지고 있지 않기 때문에, 해당 빈을 Mock으로 설정해도 적용이 되지 않는다. 

그러므로 `@DataJpaTest` 를 `@SpringBootTest` 로 변경하고, `AuditingEntityListener` 을 Mock으로 등록한다.

given, when 등을 설정하지 않아도 Mock으로 생성한 `AuditingEntityListener` 의 핸들러가 `null` 로 설정되기에 `Auditing`이 적용되지 않는다.

```java
@PrePersist
public void touchForCreate(Object target) {

	Assert.notNull(target, "Entity must not be null!");

	// handler 가 null 이면 아무것도 안함.
	if (handler != null) {

		AuditingHandler object = handler.getObject();
		if (object != null) {
			object.markCreated(target);
		}
	}
}
```

이제 `persist` 한 엔티티를 디버깅해보면 생성 시각이 설정한 그대로 등록되어 있는 것을 볼 수 있다.

![스크린샷 2021-09-05 오후 10 48 15](https://user-images.githubusercontent.com/56301069/132129775-ca202e60-d081-4a4b-99ea-a61857edca1a.png)

### 끝!