### PR TITLE
개인 정보 수정 및 탈퇴한 경우 유저 정보 갱신

### DIFF
--- a/frontend/src/components/Auth/AuthProvider/AuthProvider.tsx
+++ b/frontend/src/components/Auth/AuthProvider/AuthProvider.tsx
@@ -81,7 +81,9 @@ const AuthProvider = ({ children }: Props) => {
 
   const isAuthenticated = user !== null || accessToken !== null;
 
-  return <AuthContext.Provider value={{ isAuthenticated, user, login, logout }}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, user, authCheck, login, logout }}>{children}</AuthContext.Provider>
+  );
 };
 
 export default AuthProvider;

--- a/frontend/src/components/Reviewer/MyReviewerEdit/MyReviewerEdit.tsx
+++ b/frontend/src/components/Reviewer/MyReviewerEdit/MyReviewerEdit.tsx
@@ -12,6 +12,7 @@ import TextareaField from "components/FormProvider/TextareaField";
 import SpecPicker from "components/Language/SpecPicker";
 import Loading from "components/Loading/Loading";
 import { Flex } from "components/shared/Flexbox/Flexbox";
+import useAuthContext from "hooks/useAuthContext";
 import useModalContext from "hooks/useModalContext";
 import useRevalidate from "hooks/useRevalidate";
 import useToastContext from "hooks/useToastContext";
@@ -40,11 +41,11 @@ const MyReviewerEdit = ({ reviewer }: Props) => {
   const [filterLanguage, setFilterLanguage] = useState<string | null>(null);
   const [specs, setSpecs] = useState<Specs>({});
 
+  const queryClient = useQueryClient();
   const { revalidate } = useRevalidate();
   const { close } = useModalContext();
   const toast = useToastContext();
-
-  const queryClient = useQueryClient();
+  const { authCheck } = useAuthContext();
 
   const mutation = useMutation((reviewerEditFormData: ReviewerRegisterFormData) =>
     revalidate(async () => {
@@ -57,7 +58,7 @@ const MyReviewerEdit = ({ reviewer }: Props) => {
         toast(SUCCESS_MESSAGE.API.REVIEWER.EDIT);
 
         queryClient.invalidateQueries([QUERY_KEY.GET_REVIEWER, reviewer.id]);
-        queryClient.invalidateQueries(QUERY_KEY.CHECK_MEMBER);
+        authCheck();
       }
 
       return response;

--- a/frontend/src/components/Reviewer/MyReviewerInfo/MyReviewerInfo.tsx
+++ b/frontend/src/components/Reviewer/MyReviewerInfo/MyReviewerInfo.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
+import { useMutation, useQuery } from "react-query";
 
 import styled, { css } from "styled-components";
 
@@ -10,6 +10,7 @@ import Loading from "components/Loading/Loading";
 import MyReviewerEdit from "components/Reviewer/MyReviewerEdit/MyReviewerEdit";
 import Button from "components/shared/Button/Button";
 import { Flex, FlexCenter, FlexEnd } from "components/shared/Flexbox/Flexbox";
+import useAuthContext from "hooks/useAuthContext";
 import useModalContext from "hooks/useModalContext";
 import useRevalidate from "hooks/useRevalidate";
 import useToastContext from "hooks/useToastContext";
@@ -60,6 +61,7 @@ interface Props {
 
 const MyReviewerInfo = ({ reviewerId }: Props) => {
   const [openContent, setOpenContent] = useState(false);
+  const { authCheck } = useAuthContext();
 
   const { open } = useModalContext();
   const toast = useToastContext();
@@ -77,7 +79,6 @@ const MyReviewerInfo = ({ reviewerId }: Props) => {
   });
 
   const { revalidate } = useRevalidate();
-  const queryClient = useQueryClient();
 
   const deleteReviewerMutation = useMutation(() => {
     return revalidate(async () => {
@@ -85,7 +86,7 @@ const MyReviewerInfo = ({ reviewerId }: Props) => {
 
       if (response.isSuccess) {
         toast(SUCCESS_MESSAGE.API.REVIEWER.DELETE);
-        queryClient.invalidateQueries(QUERY_KEY.CHECK_MEMBER);
+        authCheck();
       }
 
       return response;

--- a/frontend/src/hooks/useAuthContext.ts
+++ b/frontend/src/hooks/useAuthContext.ts
@@ -5,6 +5,7 @@ import { User } from "types/auth";
 interface AuthContextProps {
   isAuthenticated: boolean;
   user: User | null;
+  authCheck: () => void;
   login: (user: User) => void;
   logout: () => void;
 }

--- a/frontend/src/pages/ReviewerRegister/ReviewerRegister.tsx
+++ b/frontend/src/pages/ReviewerRegister/ReviewerRegister.tsx
@@ -33,7 +33,7 @@ const ReviewerRegister = () => {
 
   const history = useHistory();
   const queryClient = useQueryClient();
-
+  const { authCheck } = useAuthContext();
   const { revalidate } = useRevalidate();
   const toast = useToastContext();
 
@@ -45,7 +45,7 @@ const ReviewerRegister = () => {
         toast(response.error.message, { type: "error" });
       } else {
         queryClient.invalidateQueries(QUERY_KEY.GET_REVIEWER_LIST);
-        queryClient.invalidateQueries(QUERY_KEY.CHECK_MEMBER);
+        authCheck();
 
         toast(SUCCESS_MESSAGE.API.REVIEWER.REGISTER);
       }

--- a/frontend/src/utils/constants/key.ts
+++ b/frontend/src/utils/constants/key.ts
@@ -4,7 +4,6 @@ export const LOCAL_STORAGE_KEY = {
 };
 
 export const QUERY_KEY = {
-  CHECK_MEMBER: "checkMember",
   OAUTH_LOGIN: "providerName",
   GET_LANGUAGE_LIST: "getLanguageList",
   GET_REVIEWER: "getReviewer",


### PR DESCRIPTION
- 기존 query를 이용해 인증 정보 관리하던 것을 useEffect에서 처리하도록 수정되어 query갱신 대신 처리해주었습니다.
