### PR TITLE
역할과 상관없이 두 멤버가 하나의 채팅방을 사용하도록 수정

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/repository/RoomRepository.java
+++ b/backend/src/main/java/com/wootech/dropthecode/repository/RoomRepository.java
@@ -6,8 +6,15 @@ import java.util.Optional;
 import com.wootech.dropthecode.domain.chatting.Room;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
-    Optional<Room> findByTeacherIdAndStudentId(Long teacherId, Long studentId);
+
+    @Query("select r from Room r " +
+            "where (r.teacher.id = :teacherId and r.student.id = :studentId) " +
+            "or (r.teacher.id = :studentId and r.student.id = :teacherId)")
+    Optional<Room> findByTeacherIdAndStudentId(@Param("teacherId") Long teacherId, @Param("studentId") Long studentId);
+
     List<Room> findByTeacherIdOrStudentId(Long teacherId, Long studentId);
 }


### PR DESCRIPTION
회원 A와 회원 B가 채팅을 할 때, 

A가 먼저 말을 걸었을 경우와 B가 먼저 말을 걸었을 경우 각각 방이 따로 생기는 이슈를 해결하였습니다.

![image](https://user-images.githubusercontent.com/50273712/133130161-77fb360c-40b0-4afd-87a5-d494bb154d1f.png)



