### PR TITLE
INFO_LOG에 sql, access, error 로그 추가

### DIFF
--- a/backend/src/main/resources/appender/access-file-appender.xml
+++ b/backend/src/main/resources/appender/access-file-appender.xml
@@ -4,7 +4,7 @@
 
         <encoder>
             <pattern>
-                [%t{yy-MM-dd} %t{HH:mm:ss}]%n[REQUEST]%n%fullRequest%n[RESPONSE]%n%fullResponse
+                [Occurred Time] - [%t{yyyy-MM-dd} %t{HH:mm:ss}]%n[REQUEST]%n%fullRequest%n[RESPONSE]%n%fullResponse
             </pattern>
         </encoder>
 

--- a/backend/src/main/resources/appender/info-file-appender.xml
+++ b/backend/src/main/resources/appender/info-file-appender.xml
@@ -1,18 +1,11 @@
 <included>
-    <property name="INFO_LOG_PATTERN" value="[Occurred Time] - [%d{yyyy-MM-dd HH:mm:ss}] [%-5p] [%-40.40logger{0}] - %m%n"/>
-
     <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>INFO</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-
-        <file>${FILE_PATH}/info.txt</file>
 
         <encoder>
             <pattern>${INFO_LOG_PATTERN}</pattern>
         </encoder>
+
+        <file>${FILE_PATH}/info.txt</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${FILE_PATH}/info.%d{yyyy-MM-dd}.%i.txt</fileNamePattern>

--- a/backend/src/main/resources/logback-access.xml
+++ b/backend/src/main/resources/logback-access.xml
@@ -1,11 +1,13 @@
 <configuration scan="true" scanPeriod="10 seconds">
 
-    <!--    Constants    -->
-    <property name="CONSOLE_LOG_PATTERN"
-              value="%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n%n"/>
+    <!--    Date Pattern Setting    -->
+    <timestamp key="DATE_FORMAT" datePattern="yyyy-MM-dd"/>
 
-    <timestamp key="DATE_FORMAT"
-               datePattern="yyyy-MM-dd"/>
+    <!--    Log Pattern Setting    -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[Occurred Time] - [%t{yyyy-MM-dd} %t{HH:mm:ss}] REQUEST AND RESPONSE%n[REQUEST]%n%fullRequest%n[RESPONSE]%n%fullResponse"/>
+    <property name="INFO_LOG_PATTERN"
+              value="[Occurred Time] - [%t{yyyy-MM-dd} %t{HH:mm:ss}] REQUEST AND RESPONSE%n[REQUEST]%n%fullRequest%n[RESPONSE]%n%fullResponse"/>
 
     <!--    Local    -->
     <springProfile name="local">
@@ -16,6 +18,8 @@
     <!--    Production    -->
     <springProfile name="prod, dev">
         <include resource="appender/access-file-appender.xml"/>
+        <include resource="appender/info-file-appender.xml"/>
         <appender-ref ref="ACCESS_FILE"/>
+        <appender-ref ref="INFO_FILE"/>
     </springProfile>
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -13,6 +13,7 @@
     <property name="INFO_LOG_PATTERN"
               value="[Occurred Time] - [%d{yyyy-MM-dd HH:mm:ss}] [%-5p] [%-40.40logger{0}] - %m%n"/>
 
+    <include resource="appender/all-console-appender.xml"/>
     <include resource="appender/info-file-appender.xml"/>
     <include resource="appender/error-file-appender.xml"/>
     <include resource="appender/sql-file-appender.xml"/>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -2,32 +2,34 @@
 <configuration scan="true" scanPeriod="10 seconds">
 
     <!--    Log Level Color Setting    -->
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="clr"
+                    converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
     <conversionRule conversionWord="wEx"
                     converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
 
+    <!--    Log Pattern Setting    -->
     <property name="CONSOLE_LOG_PATTERN"
               value="%clr([%-5p]) %clr([%-40.40logger{0}]){cyan} %clr(:){faint} %m%n"/>
+    <property name="INFO_LOG_PATTERN"
+              value="[Occurred Time] - [%d{yyyy-MM-dd HH:mm:ss}] [%-5p] [%-40.40logger{0}] - %m%n"/>
+
+    <include resource="appender/info-file-appender.xml"/>
+    <include resource="appender/error-file-appender.xml"/>
+    <include resource="appender/sql-file-appender.xml"/>
 
     <springProfile name="test">
-        <include resource="appender/all-console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE_APPENDER"/>
         </root>
     </springProfile>
 
     <springProfile name="local">
-        <include resource="appender/all-console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE_APPENDER"/>
         </root>
     </springProfile>
 
     <springProfile name="prod, dev">
-        <include resource="appender/info-file-appender.xml"/>
-        <include resource="appender/error-file-appender.xml"/>
-        <include resource="appender/sql-file-appender.xml"/>
-
         <logger name="com.wootech.dropthecode.repository.replication.ReplicationRoutingDataSource" level="DEBUG">
             <appender-ref ref="SQL_FILE"/>
         </logger>
@@ -44,7 +46,7 @@
             <appender-ref ref="SQL_FILE"/>
         </logger>
 
-        <root level="DEBUG">
+        <root level="INFO">
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="ERROR_FILE"/>
         </root>


### PR DESCRIPTION
### 기존 설정
* INFO_LOG는 하위 레벨을 포함하지 않는 오직 ` INFO` 레벨의 로그만 저장
* 그러다 보니 INFO_LOG로만 디버깅을 하기에 제한이 많음

### 변경사항
* INFO_LOG에서 다른 파일에서 로깅하는 모든 내용을 포함하게 설정
* SQL_LOG, ACCESS_LOG, ERROR_LOG에 로그들이 모두 INFO_LOG에 포함됨