### PR TITLE
SSE를 이용한 실시간 알림 & 유저별 알림 조회, 알림 읽음 처리

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -219,3 +219,11 @@ include::{snippets}/feedback-controller-test/find-all-feedback-test/auto-section
 - /feedbacks?studentId={studentId}&sort=star,asc 피드백 작성한 유저의 Id를 기준으로 별점 오름차순으로 조회 +
 - /feedbacks?studentId={studentId}&sort=star,desc 피드백 작성한 유저의 Id를 기준으로 별점 내림차순으로 조회 +
 |===
+
+== Notification API
+
+include::{snippets}/notification-controller-test/sse/auto-section.adoc[]
+
+include::{snippets}/notification-controller-test/find-all-notification/auto-section.adoc[]
+
+include::{snippets}/notification-controller-test/read-notification/auto-section.adoc[]

--- a/backend/src/main/generated/com/wootech/dropthecode/domain/QNotification.java
+++ b/backend/src/main/generated/com/wootech/dropthecode/domain/QNotification.java
@@ -1,0 +1,66 @@
+package com.wootech.dropthecode.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -1126784024L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    public final com.wootech.dropthecode.domain.review.QReview review;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath url = createString("url");
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.review = inits.isInitialized("review") ? new com.wootech.dropthecode.domain.review.QReview(forProperty("review"), inits.get("review")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/wootech/dropthecode/domain/QNotification.java
+++ b/backend/src/main/generated/com/wootech/dropthecode/domain/QNotification.java
@@ -34,6 +34,8 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public final BooleanPath isRead = createBoolean("isRead");
 
+    public final QMember receiver;
+
     public final com.wootech.dropthecode.domain.review.QReview review;
 
     //inherited
@@ -59,6 +61,7 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.receiver = inits.isInitialized("receiver") ? new QMember(forProperty("receiver"), inits.get("receiver")) : null;
         this.review = inits.isInitialized("review") ? new com.wootech.dropthecode.domain.review.QReview(forProperty("review"), inits.get("review")) : null;
     }
 

--- a/backend/src/main/generated/com/wootech/dropthecode/domain/review/QReview.java
+++ b/backend/src/main/generated/com/wootech/dropthecode/domain/review/QReview.java
@@ -36,6 +36,8 @@ public class QReview extends EntityPathBase<Review> {
     //inherited
     public final NumberPath<Long> id = _super.id;
 
+    public final SetPath<com.wootech.dropthecode.domain.Notification, com.wootech.dropthecode.domain.QNotification> notifications = this.<com.wootech.dropthecode.domain.Notification, com.wootech.dropthecode.domain.QNotification>createSet("notifications", com.wootech.dropthecode.domain.Notification.class, com.wootech.dropthecode.domain.QNotification.class, PathInits.DIRECT2);
+
     public final EnumPath<com.wootech.dropthecode.domain.Progress> progress = createEnum("progress", com.wootech.dropthecode.domain.Progress.class);
 
     public final StringPath prUrl = createString("prUrl");

--- a/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wootech/dropthecode/config/WebMvcConfig.java
@@ -36,9 +36,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(authService))
-                .addPathPatterns("/teachers", "/teachers/me", "/members/me", "/reviews", "/reviews/**", "/logout");
+                .addPathPatterns("/teachers", "/teachers/me", "/members/me", "/reviews", "/reviews/**", "/logout", "/notifications/**");
         registry.addInterceptor(new GetAuthenticationInterceptor(authService))
-                .addPathPatterns("/reviews/student/**", "/members/me");
+                .addPathPatterns("/reviews/student/**", "/members/me", "/subscribe", "/notifications");
     }
 
     @Override

--- a/backend/src/main/java/com/wootech/dropthecode/controller/NotificationController.java
+++ b/backend/src/main/java/com/wootech/dropthecode/controller/NotificationController.java
@@ -9,6 +9,7 @@ import com.wootech.dropthecode.service.NotificationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -22,8 +23,9 @@ public class NotificationController {
     }
 
     @GetMapping(value = "/subscribe/{id}", produces = "text/event-stream")
-    public SseEmitter subscribe(@PathVariable Long id) {
-        return notificationService.subscribe(id);
+    public SseEmitter subscribe(@PathVariable Long id,
+                                @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        return notificationService.subscribe(id, lastEventId);
     }
 
     @GetMapping("/notifications/{id}")

--- a/backend/src/main/java/com/wootech/dropthecode/controller/NotificationController.java
+++ b/backend/src/main/java/com/wootech/dropthecode/controller/NotificationController.java
@@ -1,0 +1,34 @@
+package com.wootech.dropthecode.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.wootech.dropthecode.dto.response.NotificationResponse;
+import com.wootech.dropthecode.service.NotificationService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping(value = "/subscribe/{id}", produces = "text/event-stream")
+    public SseEmitter subscribe(@PathVariable Long id) {
+        return notificationService.subscribe(id);
+    }
+
+    @GetMapping("/notifications/{id}")
+    public ResponseEntity<List<NotificationResponse>> notifications(@PathVariable Long id) {
+        List<NotificationResponse> notificationResponses = new ArrayList<>();
+        return ResponseEntity.ok().body(notificationResponses);
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/domain/Notification.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/Notification.java
@@ -15,6 +15,10 @@ import lombok.NoArgsConstructor;
 public class Notification extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_notification_to_receiver"))
+    private Member receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_notification_to_review"))
     private Review review;
 
@@ -25,11 +29,15 @@ public class Notification extends BaseEntity {
     private boolean isRead;
 
     @Builder
-    public Notification(Review review, String content, String url, boolean isRead) {
+    public Notification(Member receiver, Review review, String content, String url, boolean isRead) {
+        this.receiver = receiver;
         this.review = review;
         this.content = content;
         this.url = url;
         this.isRead = isRead;
     }
 
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/domain/Notification.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/Notification.java
@@ -1,0 +1,35 @@
+package com.wootech.dropthecode.domain;
+
+import javax.persistence.*;
+
+import com.wootech.dropthecode.domain.review.Review;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Notification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_notification_to_review"))
+    private Review review;
+
+    private String content;
+
+    private String url;
+
+    private boolean isRead;
+
+    @Builder
+    public Notification(Review review, String content, String url, boolean isRead) {
+        this.review = review;
+        this.content = content;
+        this.url = url;
+        this.isRead = isRead;
+    }
+
+}

--- a/backend/src/main/java/com/wootech/dropthecode/domain/review/Review.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/review/Review.java
@@ -2,7 +2,9 @@ package com.wootech.dropthecode.domain.review;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import javax.persistence.*;
 
 import com.wootech.dropthecode.domain.*;
@@ -47,6 +49,9 @@ public class Review extends BaseEntity {
 
     @OneToOne(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Feedback feedback;
+
+    @OneToMany(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private Set<Notification> notifications = new HashSet<>();
 
     @Builder
     public Review(Member teacher, Member student, String title, String content, String prUrl, Long elapsedTime, Progress progress, LocalDateTime createdAt) {

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
@@ -2,6 +2,7 @@ package com.wootech.dropthecode.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.wootech.dropthecode.domain.Notification;
 import com.wootech.dropthecode.util.LocalDateTimeToArray;
 
 import lombok.Builder;
@@ -20,5 +21,14 @@ public class NotificationResponse {
         this.url = url;
         this.createdAt = LocalDateTimeToArray.convert(createdAt);
         this.isRead = isRead;
+    }
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                                   .content(notification.getContent())
+                                   .url(notification.getUrl())
+                                   .createdAt(notification.getCreatedAt())
+                                   .isRead(notification.isRead())
+                                   .build();
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
@@ -1,0 +1,24 @@
+package com.wootech.dropthecode.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.wootech.dropthecode.util.LocalDateTimeToArray;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NotificationResponse {
+    private String content;
+    private String url;
+    private Integer[] createdAt;
+    private boolean isRead;
+
+    @Builder
+    public NotificationResponse(String content, String url, LocalDateTime createdAt, boolean isRead) {
+        this.content = content;
+        this.url = url;
+        this.createdAt = LocalDateTimeToArray.convert(createdAt);
+        this.isRead = isRead;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
@@ -35,15 +35,15 @@ public class NotificationResponse {
     /**
      * 알림 읽음 여부
      */
-    private boolean isRead;
+    private boolean read;
 
     @Builder
-    public NotificationResponse(Long id, String content, String url, LocalDateTime createdAt, boolean isRead) {
+    public NotificationResponse(Long id, String content, String url, LocalDateTime createdAt, boolean read) {
         this.id = id;
         this.content = content;
         this.url = url;
         this.createdAt = LocalDateTimeToArray.convert(createdAt);
-        this.isRead = isRead;
+        this.read = read;
     }
 
     public static NotificationResponse from(Notification notification) {
@@ -52,7 +52,7 @@ public class NotificationResponse {
                                    .content(notification.getContent())
                                    .url(notification.getUrl())
                                    .createdAt(notification.getCreatedAt())
-                                   .isRead(notification.isRead())
+                                   .read(notification.isRead())
                                    .build();
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationResponse.java
@@ -7,16 +7,39 @@ import com.wootech.dropthecode.util.LocalDateTimeToArray;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class NotificationResponse {
+    /**
+     * 알림 id
+     */
+    private Long id;
+
+    /**
+     * 알림 내용
+     */
     private String content;
+
+    /**
+     * 알림 클릭 시 이동할 url
+     */
     private String url;
+
+    /**
+     * 알림이 생성된 날짜(몇일 전 계산 위함)
+     */
     private Integer[] createdAt;
+
+    /**
+     * 알림 읽음 여부
+     */
     private boolean isRead;
 
     @Builder
-    public NotificationResponse(String content, String url, LocalDateTime createdAt, boolean isRead) {
+    public NotificationResponse(Long id, String content, String url, LocalDateTime createdAt, boolean isRead) {
+        this.id = id;
         this.content = content;
         this.url = url;
         this.createdAt = LocalDateTimeToArray.convert(createdAt);
@@ -25,6 +48,7 @@ public class NotificationResponse {
 
     public static NotificationResponse from(Notification notification) {
         return NotificationResponse.builder()
+                                   .id(notification.getId())
                                    .content(notification.getContent())
                                    .url(notification.getUrl())
                                    .createdAt(notification.getCreatedAt())

--- a/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationsResponse.java
+++ b/backend/src/main/java/com/wootech/dropthecode/dto/response/NotificationsResponse.java
@@ -1,0 +1,34 @@
+package com.wootech.dropthecode.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationsResponse {
+    /**
+     * 로그인 한 유저의 모든 알림
+     */
+    private List<NotificationResponse> notificationResponses;
+
+    /**
+     * 로그인 한 유저가 읽지 않은 알림 수
+     */
+    private long unreadCount;
+
+    @Builder
+    public NotificationsResponse(List<NotificationResponse> notificationResponses, long unreadCount) {
+        this.notificationResponses = notificationResponses;
+        this.unreadCount = unreadCount;
+    }
+
+    public static NotificationsResponse of(List<NotificationResponse> notificationResponses, long count) {
+        return NotificationsResponse.builder()
+                                    .notificationResponses(notificationResponses)
+                                    .unreadCount(count)
+                                    .build();
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/repository/EmitterRepository.java
+++ b/backend/src/main/java/com/wootech/dropthecode/repository/EmitterRepository.java
@@ -1,8 +1,8 @@
 package com.wootech.dropthecode.repository;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -10,18 +10,51 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Repository
 public class EmitterRepository {
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
 
-    public SseEmitter save(Long userId, SseEmitter sseEmitter) {
-        emitters.put(userId, sseEmitter);
+    public SseEmitter save(String id, SseEmitter sseEmitter) {
+        emitters.put(id, sseEmitter);
         return sseEmitter;
     }
 
-    public Optional<SseEmitter> findById(Long id) {
-        return Optional.ofNullable(emitters.get(id));
+    public void saveEventCache(String id, Object event) {
+        eventCache.put(id, event);
     }
 
-    public void deleteById(Long userId) {
-        emitters.remove(userId);
+    public Map<String, SseEmitter> findAllStartWithById(String id) {
+        return emitters.entrySet().stream()
+                       .filter(entry -> entry.getKey().startsWith(id))
+                       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, Object> findAllEventCacheStartWithId(String id) {
+        return eventCache.entrySet().stream()
+                         .filter(entry -> entry.getKey().startsWith(id))
+                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void deleteAllStartWithId(String id) {
+        emitters.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(id)) {
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+
+    public void deleteAllEventCacheStartWithId(String id) {
+        eventCache.forEach(
+                (key, data) -> {
+                    if (key.startsWith(id)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/repository/EmitterRepository.java
+++ b/backend/src/main/java/com/wootech/dropthecode/repository/EmitterRepository.java
@@ -1,0 +1,27 @@
+package com.wootech.dropthecode.repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepository {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long userId, SseEmitter sseEmitter) {
+        emitters.put(userId, sseEmitter);
+        return sseEmitter;
+    }
+
+    public Optional<SseEmitter> findById(Long id) {
+        return Optional.ofNullable(emitters.get(id));
+    }
+
+    public void deleteById(Long userId) {
+        emitters.remove(userId);
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/wootech/dropthecode/repository/NotificationRepository.java
@@ -1,8 +1,11 @@
 package com.wootech.dropthecode.repository;
 
+import java.util.List;
+
 import com.wootech.dropthecode.domain.Notification;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByReceiverId(Long id);
 }

--- a/backend/src/main/java/com/wootech/dropthecode/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/wootech/dropthecode/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.wootech.dropthecode.repository;
+
+import com.wootech.dropthecode.domain.Notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
@@ -7,6 +7,7 @@ import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.dto.request.RefreshTokenRequest;
 import com.wootech.dropthecode.dto.response.AccessTokenResponse;
 import com.wootech.dropthecode.exception.AuthenticationException;
+import com.wootech.dropthecode.repository.EmitterRepository;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +17,13 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
     private final RedisUtil redisUtil;
+    private final EmitterRepository emitterRepository;
 
-    public AuthService(JwtTokenProvider jwtTokenProvider, MemberService memberService, RedisUtil redisUtil) {
+    public AuthService(JwtTokenProvider jwtTokenProvider, MemberService memberService, RedisUtil redisUtil, EmitterRepository emitterRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.memberService = memberService;
         this.redisUtil = redisUtil;
+        this.emitterRepository = emitterRepository;
     }
 
     public void validatesAccessToken(String accessToken) {
@@ -63,5 +66,6 @@ public class AuthService {
     public void logout(String accessToken) {
         String id = jwtTokenProvider.getPayload(accessToken);
         redisUtil.deleteData(id);
+        emitterRepository.deleteById(Long.parseLong(id));
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
@@ -66,6 +66,7 @@ public class AuthService {
     public void logout(String accessToken) {
         String id = jwtTokenProvider.getPayload(accessToken);
         redisUtil.deleteData(id);
-        emitterRepository.deleteById(Long.parseLong(id));
+        emitterRepository.deleteAllStartWithId(id);
+        emitterRepository.deleteAllEventCacheStartWithId(id);
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
@@ -16,21 +16,18 @@ public class MemberService {
     private final TeacherLanguageService teacherLanguageService;
     private final TeacherSkillService teacherSkillService;
     private final MemberRepository memberRepository;
-    private final NotificationService notificationService;
 
     public MemberService(TeacherLanguageService teacherLanguageService, TeacherSkillService teacherSkillService,
-                         MemberRepository memberRepository, NotificationService notificationService) {
+                         MemberRepository memberRepository) {
         this.teacherLanguageService = teacherLanguageService;
         this.teacherSkillService = teacherSkillService;
         this.memberRepository = memberRepository;
-        this.notificationService = notificationService;
     }
 
     @Transactional(readOnly = true)
     public MemberResponse findByLoginMember(LoginMember loginMember) {
         loginMember.validatesAnonymous();
         Member member = findById(loginMember.getId());
-        notificationService.subscribe(member.getId());
         return MemberResponse.of(member);
     }
 

--- a/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
@@ -5,6 +5,7 @@ import javax.persistence.EntityNotFoundException;
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.dto.response.MemberResponse;
+import com.wootech.dropthecode.repository.EmitterRepository;
 import com.wootech.dropthecode.repository.MemberRepository;
 
 import org.springframework.stereotype.Service;
@@ -15,17 +16,21 @@ public class MemberService {
     private final TeacherLanguageService teacherLanguageService;
     private final TeacherSkillService teacherSkillService;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
 
-    public MemberService(TeacherLanguageService teacherLanguageService, TeacherSkillService teacherSkillService, MemberRepository memberRepository) {
+    public MemberService(TeacherLanguageService teacherLanguageService, TeacherSkillService teacherSkillService,
+                         MemberRepository memberRepository, NotificationService notificationService) {
         this.teacherLanguageService = teacherLanguageService;
         this.teacherSkillService = teacherSkillService;
         this.memberRepository = memberRepository;
+        this.notificationService = notificationService;
     }
 
     @Transactional(readOnly = true)
     public MemberResponse findByLoginMember(LoginMember loginMember) {
         loginMember.validatesAnonymous();
         Member member = findById(loginMember.getId());
+        notificationService.subscribe(member.getId());
         return MemberResponse.of(member);
     }
 

--- a/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
@@ -1,0 +1,39 @@
+package com.wootech.dropthecode.service;
+
+import java.io.IOException;
+
+import com.wootech.dropthecode.dto.response.NotificationResponse;
+import com.wootech.dropthecode.repository.EmitterRepository;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class NotificationService {
+    private static final Long DEFAULT_TIMEOUT = -1L;
+
+    private final EmitterRepository emitterRepository;
+
+    public NotificationService(EmitterRepository emitterRepository) {
+        this.emitterRepository = emitterRepository;
+    }
+
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = emitterRepository.save(userId, new SseEmitter(DEFAULT_TIMEOUT));
+        emitter.onCompletion(() -> emitterRepository.deleteById(userId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(userId));
+        return emitter;
+    }
+
+    public void send(Long userId, NotificationResponse response) {
+        emitterRepository.findById(userId)
+                         .ifPresent(emitter -> {
+                                     try {
+                                         emitter.send(SseEmitter.event().data(response));
+                                     } catch (IOException exception) {
+                                         emitterRepository.deleteById(userId);
+                                     }
+                                 }
+                         );
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.wootech.dropthecode.service;
 
 import java.io.IOException;
+import java.util.Map;
 
 import com.wootech.dropthecode.domain.Notification;
 import com.wootech.dropthecode.dto.response.NotificationResponse;
@@ -22,39 +23,48 @@ public class NotificationService {
         this.notificationRepository = notificationRepository;
     }
 
-    public SseEmitter subscribe(Long userId) {
-        SseEmitter emitter = emitterRepository.save(userId, new SseEmitter(DEFAULT_TIMEOUT));
-        emitter.onCompletion(() -> emitterRepository.deleteById(userId));
-        emitter.onTimeout(() -> emitterRepository.deleteById(userId));
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+        String id = userId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = emitterRepository.save(id, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(id));
+        emitter.onTimeout(() -> emitterRepository.deleteById(id));
 
         // 503 에러를 방지하기 위한 더미 이벤트 전송
-        try {
-            emitter.send(SseEmitter.event()
-                                   .id("${userId}_${System.currentTimeMillis()}")
-                                   .name("sse")
-                                   .data("EventStream Created. [userId=$userId]"));
-        } catch (IOException exception) {
-            throw new RuntimeException();
-        }
+        sendToClient(emitter, id, "EventStream Created. [userId=" + userId + "]");
 
         // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+        if (!lastEventId.isEmpty()) {
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithId(String.valueOf(userId));
+            events.entrySet().stream()
+                  .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                  .forEach(entry -> sendToClient(emitter, entry.getKey(), entry.getValue()));
+        }
 
         return emitter;
     }
 
+    private void sendToClient(SseEmitter emitter, String id, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                                   .id(id)
+                                   .name("sse")
+                                   .data(data));
+        } catch (IOException exception) {
+            emitterRepository.deleteById(id);
+            throw new RuntimeException("연결 오류!");
+        }
+    }
+
     public void send(Long userId, Notification notification) {
-        emitterRepository.findById(userId)
-                         .ifPresent(emitter -> {
-                                     try {
-                                         notificationRepository.save(notification);
-                                         emitter.send(SseEmitter.event()
-                                                                .id("")
-                                                                .name("sse")
-                                                                .data(NotificationResponse.from(notification)));
-                                     } catch (IOException exception) {
-                                         emitterRepository.deleteById(userId);
-                                     }
-                                 }
-                         );
+        String id = String.valueOf(userId);
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(id);
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    notificationRepository.save(notification);
+                    emitterRepository.saveEventCache(key, notification);
+                    sendToClient(emitter, key, NotificationResponse.from(notification));
+                }
+        );
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.wootech.dropthecode.domain.Notification;
+import com.wootech.dropthecode.domain.review.Review;
 import com.wootech.dropthecode.dto.response.NotificationResponse;
 import com.wootech.dropthecode.repository.EmitterRepository;
 import com.wootech.dropthecode.repository.NotificationRepository;
@@ -56,7 +57,8 @@ public class NotificationService {
         }
     }
 
-    public void send(Long userId, Notification notification) {
+    public void send(Long userId, Review review, String content) {
+        Notification notification = createNotification(review, content);
         String id = String.valueOf(userId);
         Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(id);
         sseEmitters.forEach(
@@ -66,5 +68,14 @@ public class NotificationService {
                     sendToClient(emitter, key, NotificationResponse.from(notification));
                 }
         );
+    }
+
+    private Notification createNotification(Review review, String content) {
+        return Notification.builder()
+                           .content(content)
+                           .review(review)
+                           .url("/reviews/" + review.getId())
+                           .isRead(false)
+                           .build();
     }
 }

--- a/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
@@ -2,34 +2,55 @@ package com.wootech.dropthecode.service;
 
 import java.io.IOException;
 
+import com.wootech.dropthecode.domain.Notification;
 import com.wootech.dropthecode.dto.response.NotificationResponse;
 import com.wootech.dropthecode.repository.EmitterRepository;
+import com.wootech.dropthecode.repository.NotificationRepository;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 public class NotificationService {
-    private static final Long DEFAULT_TIMEOUT = -1L;
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000;
 
     private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
 
-    public NotificationService(EmitterRepository emitterRepository) {
+    public NotificationService(EmitterRepository emitterRepository, NotificationRepository notificationRepository) {
         this.emitterRepository = emitterRepository;
+        this.notificationRepository = notificationRepository;
     }
 
     public SseEmitter subscribe(Long userId) {
         SseEmitter emitter = emitterRepository.save(userId, new SseEmitter(DEFAULT_TIMEOUT));
         emitter.onCompletion(() -> emitterRepository.deleteById(userId));
         emitter.onTimeout(() -> emitterRepository.deleteById(userId));
+
+        // 503 에러를 방지하기 위한 더미 이벤트 전송
+        try {
+            emitter.send(SseEmitter.event()
+                                   .id("${userId}_${System.currentTimeMillis()}")
+                                   .name("sse")
+                                   .data("EventStream Created. [userId=$userId]"));
+        } catch (IOException exception) {
+            throw new RuntimeException();
+        }
+
+        // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+
         return emitter;
     }
 
-    public void send(Long userId, NotificationResponse response) {
+    public void send(Long userId, Notification notification) {
         emitterRepository.findById(userId)
                          .ifPresent(emitter -> {
                                      try {
-                                         emitter.send(SseEmitter.event().data(response));
+                                         notificationRepository.save(notification);
+                                         emitter.send(SseEmitter.event()
+                                                                .id("")
+                                                                .name("sse")
+                                                                .data(NotificationResponse.from(notification)));
                                      } catch (IOException exception) {
                                          emitterRepository.deleteById(userId);
                                      }

--- a/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/NotificationService.java
@@ -69,10 +69,10 @@ public class NotificationService {
     public void send(Member receiver, Review review, String content) {
         Notification notification = createNotification(receiver, review, content);
         String id = String.valueOf(receiver.getId());
+        notificationRepository.save(notification);
         Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(id);
         sseEmitters.forEach(
                 (key, emitter) -> {
-                    notificationRepository.save(notification);
                     emitterRepository.saveEventCache(key, notification);
                     sendToClient(emitter, key, NotificationResponse.from(notification));
                 }

--- a/backend/src/main/java/com/wootech/dropthecode/service/ReviewService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/ReviewService.java
@@ -30,12 +30,15 @@ public class ReviewService {
     private final TeacherService teacherService;
     private final FeedbackService feedbackService;
     private final ReviewRepository reviewRepository;
+    private final NotificationService notificationService;
 
-    public ReviewService(MemberService memberService, TeacherService teacherService, FeedbackService feedbackService, ReviewRepository reviewRepository) {
+    public ReviewService(MemberService memberService, TeacherService teacherService, FeedbackService feedbackService,
+                         ReviewRepository reviewRepository, NotificationService notificationService) {
         this.memberService = memberService;
         this.teacherService = teacherService;
         this.feedbackService = feedbackService;
         this.reviewRepository = reviewRepository;
+        this.notificationService = notificationService;
     }
 
     @Transactional
@@ -52,6 +55,8 @@ public class ReviewService {
                               .progress(Progress.PENDING)
                               .build();
         Review savedReview = reviewRepository.save(review);
+        notificationService.send(teacher.getId(), savedReview, "새로운 리뷰 요청이 도착했습니다!");
+
         return savedReview.getId();
     }
 
@@ -100,12 +105,14 @@ public class ReviewService {
     public void denyReview(LoginMember loginMember, Long id) {
         Review review = findById(id);
         new PendingReview(review).deny(loginMember.getId());
+        notificationService.send(review.getStudent().getId(), review, "리뷰 요청이 거절되었습니다.");
     }
 
     @Transactional
     public void acceptReview(LoginMember loginMember, Long id) {
         Review review = findById(id);
         new PendingReview(review).accept(loginMember.getId());
+        notificationService.send(review.getStudent().getId(), review, "리뷰 요청이 수락되었습니다.");
     }
 
     @Transactional
@@ -113,6 +120,7 @@ public class ReviewService {
         Review review = findById(id);
         new OnGoingReview(review).complete(loginMember.getId());
         teacherService.updateAverageReviewTime(loginMember.getId(), review.calculateElapsedTime());
+        notificationService.send(review.getStudent().getId(), review, "리뷰가 완료되었습니다. 리뷰어에 대한 피드백을 입력해주세요.");
     }
 
     @Transactional
@@ -120,6 +128,7 @@ public class ReviewService {
         Review review = findById(id);
         feedbackService.create(review, feedbackRequest);
         new CompletedReview(review).finish(loginMember.getId());
+        notificationService.send(review.getTeacher().getId(), review, "모든 리뷰가 완료되었습니다. 피드백을 확인해주세요");
     }
 
     @Transactional

--- a/backend/src/main/java/com/wootech/dropthecode/service/ReviewService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/ReviewService.java
@@ -55,7 +55,7 @@ public class ReviewService {
                               .progress(Progress.PENDING)
                               .build();
         Review savedReview = reviewRepository.save(review);
-        notificationService.send(teacher.getId(), savedReview, "새로운 리뷰 요청이 도착했습니다!");
+        notificationService.send(teacher, savedReview, "새로운 리뷰 요청이 도착했습니다!");
 
         return savedReview.getId();
     }
@@ -105,14 +105,14 @@ public class ReviewService {
     public void denyReview(LoginMember loginMember, Long id) {
         Review review = findById(id);
         new PendingReview(review).deny(loginMember.getId());
-        notificationService.send(review.getStudent().getId(), review, "리뷰 요청이 거절되었습니다.");
+        notificationService.send(review.getStudent(), review, "리뷰 요청이 거절되었습니다.");
     }
 
     @Transactional
     public void acceptReview(LoginMember loginMember, Long id) {
         Review review = findById(id);
         new PendingReview(review).accept(loginMember.getId());
-        notificationService.send(review.getStudent().getId(), review, "리뷰 요청이 수락되었습니다.");
+        notificationService.send(review.getStudent(), review, "리뷰 요청이 수락되었습니다.");
     }
 
     @Transactional
@@ -120,7 +120,7 @@ public class ReviewService {
         Review review = findById(id);
         new OnGoingReview(review).complete(loginMember.getId());
         teacherService.updateAverageReviewTime(loginMember.getId(), review.calculateElapsedTime());
-        notificationService.send(review.getStudent().getId(), review, "리뷰가 완료되었습니다. 리뷰어에 대한 피드백을 입력해주세요.");
+        notificationService.send(review.getStudent(), review, "리뷰가 완료되었습니다. 리뷰어에 대한 피드백을 입력해주세요.");
     }
 
     @Transactional
@@ -128,7 +128,7 @@ public class ReviewService {
         Review review = findById(id);
         feedbackService.create(review, feedbackRequest);
         new CompletedReview(review).finish(loginMember.getId());
-        notificationService.send(review.getTeacher().getId(), review, "모든 리뷰가 완료되었습니다. 피드백을 확인해주세요");
+        notificationService.send(review.getTeacher(), review, "모든 리뷰가 완료되었습니다. 피드백을 확인해주세요");
     }
 
     @Transactional

--- a/backend/src/main/resources/db/migration/V3__create_notification.sql
+++ b/backend/src/main/resources/db/migration/V3__create_notification.sql
@@ -1,0 +1,16 @@
+create table notification
+(
+    id          bigint   not null auto_increment,
+    review_id   bigint   not null,
+    content     varchar(255) not null,
+    url         varchar(255),
+    is_read     tinyint(1),
+    created_at  datetime(6) not null,
+    updated_at  datetime(6),
+    primary key (id)
+) engine=InnoDB;
+
+alter table notification
+    add constraint fk_notification_to_review
+        foreign key (review_id)
+            references review (id);

--- a/backend/src/main/resources/db/migration/V3__create_notification.sql
+++ b/backend/src/main/resources/db/migration/V3__create_notification.sql
@@ -1,6 +1,7 @@
 create table notification
 (
     id          bigint   not null auto_increment,
+    receiver_id bigint   not null,
     review_id   bigint   not null,
     content     varchar(255) not null,
     url         varchar(255),
@@ -9,6 +10,11 @@ create table notification
     updated_at  datetime(6),
     primary key (id)
 ) engine=InnoDB;
+
+alter table notification
+    add constraint fk_notification_to_receiver
+        foreign key (receiver_id)
+            references member (id);
 
 alter table notification
     add constraint fk_notification_to_review

--- a/backend/src/main/resources/static/notification.html
+++ b/backend/src/main/resources/static/notification.html
@@ -16,7 +16,8 @@
         // 클라이언트의 요청으로 생성된 EventStream은 서버에서 연결을 종료(서버에서의 EventStream 타임아웃 만료, 서버 재시작 등)하지 않는 한 계속 유지된다.
         // 만약, 언급한 이유로 서버로부터 연결이 종료된다면 브라우저 레벨에서 자동으로 새로운 EventStream의 생성을 시도하며,
         // 서버가 정상적인 상태라면 새롭게 생성된 EventStream은 다시 유효하게 작동하게 된다.
-        const eventSource = new EventSource(`/subscribe/` + id);
+        const eventSource = new EventSource(`/subscribe`);
+        // TODO access-token 헤더에 넣어야지 작동
         eventSource.addEventListener("sse", function (event) {
             console.log(event.data);
 

--- a/backend/src/main/resources/static/notification.html
+++ b/backend/src/main/resources/static/notification.html
@@ -16,10 +16,54 @@
         // 클라이언트의 요청으로 생성된 EventStream은 서버에서 연결을 종료(서버에서의 EventStream 타임아웃 만료, 서버 재시작 등)하지 않는 한 계속 유지된다.
         // 만약, 언급한 이유로 서버로부터 연결이 종료된다면 브라우저 레벨에서 자동으로 새로운 EventStream의 생성을 시도하며,
         // 서버가 정상적인 상태라면 새롭게 생성된 EventStream은 다시 유효하게 작동하게 된다.
-        // (다만, 클라이언트에서 연결 종료 인지 후 재생성 요청 과정에서 서버가 전송한 Event는 유실된다.)
         const eventSource = new EventSource(`/subscribe/` + id);
         eventSource.addEventListener("sse", function (event) {
             console.log(event.data);
+
+            const data = JSON.parse(event.data);
+
+            (async () => {
+                // create and show the notification
+                const showNotification = () => {
+                    // create a new notification
+                    const notification = new Notification('코드 봐줘', {
+                        body: data.content,
+                        icon: './img/js.png'
+                    });
+
+                    // close the notification after 10 seconds
+                    setTimeout(() => {
+                        notification.close();
+                    }, 10 * 1000);
+
+                    // navigate to a URL when clicked
+                    notification.addEventListener('click', () => {
+                        window.open(data.url, '_blank');
+                    });
+                }
+
+                // show an error message
+                const showError = () => {
+                    const error = document.querySelector('.error');
+                    error.style.display = 'block';
+                    error.textContent = 'You blocked the notifications';
+                }
+
+                // check notification permission
+                let granted = false;
+
+                if (Notification.permission === 'granted') {
+                    granted = true;
+                } else if (Notification.permission !== 'denied') {
+                    let permission = await Notification.requestPermission();
+                    granted = permission === 'granted' ? true : false;
+                }
+
+                // show notification or error
+                granted ? showNotification() : showError();
+
+            })();
         })
     }
+
 </script>

--- a/backend/src/main/resources/static/notification.html
+++ b/backend/src/main/resources/static/notification.html
@@ -12,13 +12,14 @@
 <script type="text/javaScript">
     function login() {
         const id = document.getElementById('id').value;
+
+        // 클라이언트의 요청으로 생성된 EventStream은 서버에서 연결을 종료(서버에서의 EventStream 타임아웃 만료, 서버 재시작 등)하지 않는 한 계속 유지된다.
+        // 만약, 언급한 이유로 서버로부터 연결이 종료된다면 브라우저 레벨에서 자동으로 새로운 EventStream의 생성을 시도하며,
+        // 서버가 정상적인 상태라면 새롭게 생성된 EventStream은 다시 유효하게 작동하게 된다.
+        // (다만, 클라이언트에서 연결 종료 인지 후 재생성 요청 과정에서 서버가 전송한 Event는 유실된다.)
         const eventSource = new EventSource(`/subscribe/` + id);
-        eventSource.onmessage = event => {
-            const data = JSON.parse(event.data);
-            console.log(data);
-        };
-        eventSource.onerror = error => {
-            eventSource.close();
-        };
+        eventSource.addEventListener("sse", function (event) {
+            console.log(event.data);
+        })
     }
 </script>

--- a/backend/src/main/resources/static/notification.html
+++ b/backend/src/main/resources/static/notification.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Notification Test Page</title>
+</head>
+<body>
+<input type="text" id="id"/>
+<button type="button" onclick="login()">로그인</button>
+</body>
+</html>
+<script type="text/javaScript">
+    function login() {
+        const id = document.getElementById('id').value;
+        const eventSource = new EventSource(`/subscribe/` + id);
+        eventSource.onmessage = event => {
+            const data = JSON.parse(event.data);
+            console.log(data);
+        };
+        eventSource.onerror = error => {
+            eventSource.close();
+        };
+    }
+</script>

--- a/backend/src/test/java/com/wootech/dropthecode/ControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/ControllerTest.java
@@ -41,4 +41,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected ChattingService chattingService;
+
+    @MockBean
+    protected NotificationService notificationService;
 }

--- a/backend/src/test/java/com/wootech/dropthecode/acceptance/NotificationAcceptanceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/acceptance/NotificationAcceptanceTest.java
@@ -1,0 +1,99 @@
+package com.wootech.dropthecode.acceptance;
+
+import com.wootech.dropthecode.dto.request.ReviewRequest;
+import com.wootech.dropthecode.dto.response.LoginResponse;
+import com.wootech.dropthecode.dto.response.NotificationsResponse;
+
+import org.springframework.http.HttpStatus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import static com.wootech.dropthecode.acceptance.ReviewAcceptanceTest.리뷰_요청_데이터;
+import static com.wootech.dropthecode.acceptance.ReviewAcceptanceTest.새로운_리뷰_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@DisplayName("알림 관련 인수테스트")
+class NotificationAcceptanceTest extends AcceptanceTest {
+    private LoginResponse student;
+    private LoginResponse teacher;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        student = 학생_로그인되어_있음("air");
+        teacher = 리뷰어_로그인되어_있음("curry");
+    }
+
+    @Test
+    @DisplayName("로그인 멤버의 모든 알림 조회")
+    void findAllNotification() {
+        // given
+        ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
+        새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+
+        // when
+        ExtractableResponse<Response> response = 모든_알림_조회(teacher.getAccessToken());
+        NotificationsResponse result = response.as(NotificationsResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.getNotificationResponses()).hasSize(1);
+        assertThat(result.getUnreadCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림 읽기")
+    void readNotification() {
+        // given
+        ReviewRequest reviewRequest = 리뷰_요청_데이터(student.getId(), teacher.getId());
+        새로운_리뷰_요청(student.getAccessToken(), reviewRequest);
+
+        // when
+        ExtractableResponse<Response> findNotification = 모든_알림_조회(teacher.getAccessToken());
+        NotificationsResponse original = findNotification.as(NotificationsResponse.class);
+        Long notificationId = original.getNotificationResponses().get(0).getId();
+
+        ExtractableResponse<Response> read = 알림_읽기_요청(teacher.getAccessToken(), notificationId);
+
+        ExtractableResponse<Response> afterRead = 모든_알림_조회(teacher.getAccessToken());
+        NotificationsResponse result = afterRead.as(NotificationsResponse.class);
+
+        // then
+        assertThat(read.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(afterRead.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.getNotificationResponses()).hasSize(1);
+        assertThat(result.getUnreadCount()).isEqualTo(0);
+    }
+
+    public static ExtractableResponse<Response> 모든_알림_조회(String accessToken) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .accept(APPLICATION_JSON_VALUE)
+                          .when()
+                          .get("/notifications")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 알림_읽기_요청(String accessToken, Long notificationId) {
+        return RestAssured.given()
+                          .log().all()
+                          .header("Authorization", "Bearer " + accessToken)
+                          .accept(APPLICATION_JSON_VALUE)
+                          .when()
+                          .patch("/notifications/" + notificationId)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}

--- a/backend/src/test/java/com/wootech/dropthecode/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/NotificationControllerTest.java
@@ -63,21 +63,21 @@ class NotificationControllerTest extends RestApiDocumentTest {
                                     .content("새로운 리뷰 요청이 도착했습니다!")
                                     .url("/reviews/3")
                                     .createdAt(LocalDateTime.now().plusDays(3))
-                                    .isRead(false)
+                                    .read(false)
                                     .build(),
                 NotificationResponse.builder()
                                     .id(15L)
                                     .content("리뷰 요청이 수락되었습니다.")
                                     .url("/reviews/2")
                                     .createdAt(LocalDateTime.now().plusDays(1))
-                                    .isRead(false)
+                                    .read(false)
                                     .build(),
                 NotificationResponse.builder()
                                     .id(10L)
                                     .content("리뷰가 완료되었습니다. 리뷰어에 대한 피드백을 입력해주세요.")
                                     .url("/reviews/1")
                                     .createdAt(LocalDateTime.now())
-                                    .isRead(true)
+                                    .read(true)
                                     .build()
         );
         NotificationsResponse notificationsResponse = new NotificationsResponse(notificationResponses, 2L);

--- a/backend/src/test/java/com/wootech/dropthecode/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/controller/NotificationControllerTest.java
@@ -1,0 +1,107 @@
+package com.wootech.dropthecode.controller;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import com.wootech.dropthecode.controller.util.RestDocsMockMvcUtils;
+import com.wootech.dropthecode.dto.response.NotificationResponse;
+import com.wootech.dropthecode.dto.response.NotificationsResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class NotificationControllerTest extends RestApiDocumentTest {
+
+    @Autowired
+    private NotificationController notificationController;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.restDocsMockMvc = RestDocsMockMvcUtils.successRestDocsMockMvc(provider, notificationController);
+        this.failRestDocsMockMvc = RestDocsMockMvcUtils.failRestDocsMockMvc(provider, notificationController);
+    }
+
+    @Test
+    @DisplayName("sse 연결")
+    void sse() throws Exception {
+        // given
+        given(notificationService.subscribe(any(), anyString())).willReturn(new SseEmitter());
+
+        // when
+        ResultActions result = this.restDocsMockMvc.perform(
+                get("/subscribe")
+                        .with(userToken())
+                        .accept(MediaType.TEXT_EVENT_STREAM_VALUE)
+                        .header("Last-Event-ID", "1_1631593143664"));
+
+        // then
+        result.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("로그인 한 사용자의 모든 알림 조회")
+    void findAllNotification() throws Exception {
+        // given
+        List<NotificationResponse> notificationResponses = Arrays.asList(
+                NotificationResponse.builder()
+                                    .id(23L)
+                                    .content("새로운 리뷰 요청이 도착했습니다!")
+                                    .url("/reviews/3")
+                                    .createdAt(LocalDateTime.now().plusDays(3))
+                                    .isRead(false)
+                                    .build(),
+                NotificationResponse.builder()
+                                    .id(15L)
+                                    .content("리뷰 요청이 수락되었습니다.")
+                                    .url("/reviews/2")
+                                    .createdAt(LocalDateTime.now().plusDays(1))
+                                    .isRead(false)
+                                    .build(),
+                NotificationResponse.builder()
+                                    .id(10L)
+                                    .content("리뷰가 완료되었습니다. 리뷰어에 대한 피드백을 입력해주세요.")
+                                    .url("/reviews/1")
+                                    .createdAt(LocalDateTime.now())
+                                    .isRead(true)
+                                    .build()
+        );
+        NotificationsResponse notificationsResponse = new NotificationsResponse(notificationResponses, 2L);
+        given(notificationService.findAllById(any())).willReturn(notificationsResponse);
+
+        // when
+        ResultActions result = this.restDocsMockMvc.perform(
+                get("/notifications")
+                        .with(userToken()));
+
+        // then
+        result.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("안 읽은 알림 클릭 시 읽음 상태로 변경")
+    void readNotification() throws Exception {
+        //given
+        // when
+        ResultActions result = this.restDocsMockMvc.perform(
+                patch("/notifications/{id}", 1)
+                        .with(userToken()));
+
+        // then
+        result.andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
### 구현 기능
- SSE(Server Sent Events)를 이용한 실시간 알림 기능 구현(로그인 한 상태면 실시간 웹 알림)
  - [선생님 입장]
    - 새로운 리뷰 요청이 온 경우
    - 리뷰 상태가 FINISHED가 된 경우 피드백을 확인하라는 알림
  - [학생 입장]
    - 리뷰 요청이 거절된 경우
    - 리뷰 요청이 수락된 경우
    - 선생님이 리뷰를 완료한 경우
- 로그인 한 유저의 전체 알림 목록 조회
- 읽지 않은 알림 읽음 처리

### 보완할 것 
- sse 연결 테스트를 어떻게 해야할지 아직 잘 모르겠어서 추후에 추가하겠습니다. 조금 찾아봤는데, rest assured에서는 지원하지 않는 것 같습니다.
- 읽지 않은 채팅이 있는 경우도 알림을 보내주면 좋을 것 같습니다. 이 경우는 채팅 하나하나당 모두 알림 테이블에 저장하기 보다는 다른 방식을 생각해보는 게 좋을 것 같습니다.

<hr>

~## 문서화는 내일 중으로 완료하겠습니다!~

문서화: https://velog.io/@max9106/Spring-SSE-Server-Sent-Events%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%95%8C%EB%A6%BC