### PR TITLE
fix: email이 존재하지 않는 경우 빈 String으로 대치

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/domain/oauth/OauthAttributes.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/oauth/OauthAttributes.java
@@ -9,7 +9,7 @@ public enum OauthAttributes {
         public UserProfile of(Map<String, Object> attributes) {
             return UserProfile.builder()
                               .oauthId(String.valueOf(attributes.get("id")))
-                              .email((String) attributes.get("email"))
+                              .email((String) attributes.getOrDefault("email", ""))
                               .name((String) attributes.get("name"))
                               .imageUrl((String) attributes.get("avatar_url"))
                               .githubUrl((String) attributes.get("html_url"))


### PR DESCRIPTION
### 오류
* Github 로그인 시에 로그인 하려는 사용자의 Github 계정에 email이 등록되어 있지 않거나 보안 정책으로 막아놓은 경우 로그인이 불가능한 오류

### 해결
* 현재 email을 사용하는 내부 로직이 없으므로(있다면 말해주세요ㅜㅜ), 빈 String으로 대치하고 추후에 개인정보를 변경할 수 있는 방법을 생각