### PR TITLE
refresh token 레디스 저장시 expired time 지정

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/controller/auth/util/JwtTokenProvider.java
+++ b/backend/src/main/java/com/wootech/dropthecode/controller/auth/util/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Random;
 
+import com.wootech.dropthecode.domain.Token;
 import com.wootech.dropthecode.exception.AuthenticationException;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -20,15 +21,17 @@ public class JwtTokenProvider {
     @Value("${jwt.token.secret-key:secret-key}")
     private String secretKey;
 
-    public String createAccessToken(String payload) {
-        return createToken(payload, accessTokenValidityInMilliseconds);
+    public Token createAccessToken(String payload) {
+        String value = createToken(payload, accessTokenValidityInMilliseconds);
+        return new Token(value, accessTokenValidityInMilliseconds);
     }
 
-    public String createRefreshToken() {
+    public Token createRefreshToken() {
         byte[] array = new byte[7];
         new Random().nextBytes(array);
         String generatedString = new String(array, StandardCharsets.UTF_8);
-        return createToken(generatedString, refreshTokenValidityInMilliseconds);
+        String value = createToken(generatedString, refreshTokenValidityInMilliseconds);
+        return new Token(value, refreshTokenValidityInMilliseconds);
     }
 
     public String createToken(String payload, long expireLength) {

--- a/backend/src/main/java/com/wootech/dropthecode/domain/Token.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/Token.java
@@ -1,0 +1,16 @@
+package com.wootech.dropthecode.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Token {
+    private String value;
+    private long expiredTime;
+
+    public Token(String value, long expiredTime) {
+        this.value = value;
+        this.expiredTime = expiredTime;
+    }
+}

--- a/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/AuthService.java
@@ -4,6 +4,7 @@ import com.wootech.dropthecode.controller.auth.util.JwtTokenProvider;
 import com.wootech.dropthecode.controller.auth.util.RedisUtil;
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
+import com.wootech.dropthecode.domain.Token;
 import com.wootech.dropthecode.dto.request.RefreshTokenRequest;
 import com.wootech.dropthecode.dto.response.AccessTokenResponse;
 import com.wootech.dropthecode.exception.AuthenticationException;
@@ -54,9 +55,9 @@ public class AuthService {
             throw new AuthenticationException("refresh token이 유효하지 않습니다.");
         }
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(id);
+        Token newAccessToken = jwtTokenProvider.createAccessToken(id);
 
-        return new AccessTokenResponse(newAccessToken);
+        return new AccessTokenResponse(newAccessToken.getValue());
     }
 
     @Transactional

--- a/backend/src/main/java/com/wootech/dropthecode/service/OauthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/OauthService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.wootech.dropthecode.controller.auth.util.JwtTokenProvider;
 import com.wootech.dropthecode.controller.auth.util.RedisUtil;
 import com.wootech.dropthecode.domain.Member;
+import com.wootech.dropthecode.domain.Token;
 import com.wootech.dropthecode.domain.oauth.InMemoryProviderRepository;
 import com.wootech.dropthecode.domain.oauth.OauthAttributes;
 import com.wootech.dropthecode.domain.oauth.OauthProvider;
@@ -50,10 +51,10 @@ public class OauthService {
 
         Member member = saveOrUpdate(userProfile);
 
-        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(member.getId()));
-        String refreshToken = jwtTokenProvider.createRefreshToken();
+        Token accessToken = jwtTokenProvider.createAccessToken(String.valueOf(member.getId()));
+        Token refreshToken = jwtTokenProvider.createRefreshToken();
 
-        redisUtil.setData(String.valueOf(member.getId()), refreshToken);
+        redisUtil.setDataExpire(String.valueOf(member.getId()), refreshToken.getValue(), refreshToken.getExpiredTime());
 
         return LoginResponse.builder()
                             .id(member.getId())
@@ -63,8 +64,8 @@ public class OauthService {
                             .githubUrl(member.getGithubUrl())
                             .role(member.getRole())
                             .tokenType(BEARER_TYPE)
-                            .accessToken(accessToken)
-                            .refreshToken(refreshToken)
+                            .accessToken(accessToken.getValue())
+                            .refreshToken(refreshToken.getValue())
                             .build();
     }
 

--- a/backend/src/test/java/com/wootech/dropthecode/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/wootech/dropthecode/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.wootech.dropthecode.controller.auth.util.JwtTokenProvider;
 import com.wootech.dropthecode.controller.auth.util.RedisUtil;
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Role;
+import com.wootech.dropthecode.domain.Token;
 import com.wootech.dropthecode.dto.request.RefreshTokenRequest;
 import com.wootech.dropthecode.dto.response.AccessTokenResponse;
 import com.wootech.dropthecode.exception.AuthenticationException;
@@ -93,7 +94,7 @@ class AuthServiceTest {
         given(jwtTokenProvider.validateToken(anyString())).willReturn(true);
         given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
         given(redisUtil.getData(anyString())).willReturn(refreshToken);
-        given(jwtTokenProvider.createAccessToken(anyString())).willReturn(newAccessToken);
+        given(jwtTokenProvider.createAccessToken(anyString())).willReturn(new Token(newAccessToken, 1L));
 
         // when
         AccessTokenResponse response = authService.refreshAccessToken(accessToken, new RefreshTokenRequest(refreshToken));
@@ -140,7 +141,7 @@ class AuthServiceTest {
         given(jwtTokenProvider.validateToken(anyString())).willReturn(true);
         given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
         given(redisUtil.getData(anyString())).willReturn(refreshToken);
-        given(jwtTokenProvider.createAccessToken(anyString())).willReturn(newAccessToken);
+        given(jwtTokenProvider.createAccessToken(anyString())).willReturn(new Token(newAccessToken, 1L));
 
         // when
         AccessTokenResponse response = authService.refreshAccessToken(accessToken, new RefreshTokenRequest(refreshToken));


### PR DESCRIPTION
기존에 레디스에 refresh token을 저장할 때 expired time을 지정해주지 않아서, refresh token자체는 만료가 되어도 redis에는 값이 남아있는 문제가 있었습니다.

레디스 저장시 expired time을 설정해주어 이를 해결했습니다.