### PR TITLE
웹소켓 auto reconnect가 되지 않았던 Stomp.over 코드 수정

### DIFF
--- a/frontend/src/components/StompProvider/StompProvider.tsx
+++ b/frontend/src/components/StompProvider/StompProvider.tsx
@@ -29,9 +29,11 @@ const StompProvider = ({ children }: Props) => {
   };
 
   const connect = (roomId: number) => {
-    const socket = new WebSocket(process.env.SOCKET_URL as string);
+    new WebSocket(process.env.SOCKET_URL as string);
 
-    stompClient.current = Stomp.over(socket);
+    stompClient.current = Stomp.over(() => {
+      return new WebSocket(process.env.SOCKET_URL as string);
+    });
 
     stompClient.current.configure({
       reconnectDelay: 5000,

--- a/frontend/src/components/StompProvider/StompProvider.tsx
+++ b/frontend/src/components/StompProvider/StompProvider.tsx
@@ -29,8 +29,6 @@ const StompProvider = ({ children }: Props) => {
   };
 
   const connect = (roomId: number) => {
-    new WebSocket(process.env.SOCKET_URL as string);
-
     stompClient.current = Stomp.over(() => {
       return new WebSocket(process.env.SOCKET_URL as string);
     });


### PR DESCRIPTION
- auto reconnect가 되지 않아 아래와 같은 에러가 발생하던 웹소켓의 Stomp.over 코드 수정
- 참고 https://stomp-js.github.io/stomp-websocket/codo/extra/docs-src/Upgrade.md.html#toc_2 
<img width="540" alt="스크린샷 2021-10-24 오후 3 32 53" src="https://user-images.githubusercontent.com/67591151/138583567-46456283-8bd5-41e5-93bc-542040b76b4d.png">
