### PR TITLE
github 계정에 email과 name이 없는 경우 default 값주기

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/domain/oauth/OauthAttributes.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/oauth/OauthAttributes.java
@@ -7,10 +7,18 @@ public enum OauthAttributes {
     GITHUB("github") {
         @Override
         public UserProfile of(Map<String, Object> attributes) {
+            String email = (String) attributes.get("email");
+            String name = (String) attributes.get("name");
+            if (email == null) {
+                email = "등록되지 않은 이메일";
+            }
+            if (name == null) {
+                name = "등록되지 않은 이름";
+            }
             return UserProfile.builder()
                               .oauthId(String.valueOf(attributes.get("id")))
-                              .email((String) attributes.getOrDefault("email", ""))
-                              .name((String) attributes.get("name"))
+                              .email(email)
+                              .name(name)
                               .imageUrl((String) attributes.get("avatar_url"))
                               .githubUrl((String) attributes.get("html_url"))
                               .build();


### PR DESCRIPTION
github 계정에 email과 name이 없는 경우 null 값 때문에 로그인을 할 수 없는 문제가 발생

email이 null인 경우: 등록되지 않은 이메일
name이 null인 경우: 등록되지 않은 이름 

으로 디폴트값을 지정