### PR TITLE
리뷰어 정보 수정 및 등록 시 나타나던 버그 수정

### DIFF
--- a/frontend/src/components/FormProvider/TextareaField.tsx
+++ b/frontend/src/components/FormProvider/TextareaField.tsx
@@ -16,7 +16,13 @@ const TextareaField = ({ name, initialValue, ...props }: Props) => {
   }, []);
 
   return (
-    <Textarea value={values[name]} name={name} errorMessage={errorMessages[name]} onChange={onChange} {...props} />
+    <Textarea
+      value={values[name] || ""}
+      name={name}
+      errorMessage={errorMessages[name]}
+      onChange={onChange}
+      {...props}
+    />
   );
 };
 

--- a/frontend/src/components/Reviewer/MyReviewerEdit/MyReviewerEdit.tsx
+++ b/frontend/src/components/Reviewer/MyReviewerEdit/MyReviewerEdit.tsx
@@ -52,7 +52,7 @@ const MyReviewerEdit = ({ reviewer }: Props) => {
       const response = await editReviewer(reviewerEditFormData);
 
       if (!response.isSuccess) {
-        toast(response.error.errorMessage);
+        toast(response.error.errorMessage, { type: "error" });
       } else {
         close();
         toast(SUCCESS_MESSAGE.API.REVIEWER.EDIT);


### PR DESCRIPTION
- QA시, 리뷰어 등록 실패 후 textArea에 값이 남아있어도 이를 빈값으로 인식하던 버그 발견
  - 입력 실패 시, 모든 input과 textArea의 값을 빈값으로 초기화하는 방식으로 변경
  - 모달 창을 닫고 재수정 시도 시 다시 기존 값 자동 완성
- QA시, 공백을 입력하면 에러 메시지 토스트가 초록색으로 뜨던 버그 발견
  - 에러 메시지 토스트 빨간색으로 수정