### PR TITLE
회원탈퇴 후 다시 리뷰어 등록하려고 할 경우 등록 실패 수정

### DIFF
--- a/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
+++ b/backend/src/main/java/com/wootech/dropthecode/domain/TeacherProfile.java
@@ -8,6 +8,7 @@ import javax.persistence.*;
 
 import com.wootech.dropthecode.domain.bridge.TeacherLanguage;
 import com.wootech.dropthecode.domain.bridge.TeacherSkill;
+import com.wootech.dropthecode.dto.request.TeacherRegistrationRequest;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -80,6 +81,11 @@ public class TeacherProfile {
         this.title = title;
         this.content = content;
         this.career = career;
+    }
+
+    public TeacherProfile update(TeacherRegistrationRequest teacherRegistrationRequest) {
+        update(teacherRegistrationRequest.getTitle(), teacherRegistrationRequest.getContent(), teacherRegistrationRequest.getCareer());
+        return this;
     }
 
     public void updateReviewCountAndTime(Long newReviewTime) {

--- a/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/MemberService.java
@@ -5,7 +5,6 @@ import javax.persistence.EntityNotFoundException;
 import com.wootech.dropthecode.domain.LoginMember;
 import com.wootech.dropthecode.domain.Member;
 import com.wootech.dropthecode.dto.response.MemberResponse;
-import com.wootech.dropthecode.repository.EmitterRepository;
 import com.wootech.dropthecode.repository.MemberRepository;
 
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/wootech/dropthecode/service/OauthService.java
+++ b/backend/src/main/java/com/wootech/dropthecode/service/OauthService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.wootech.dropthecode.controller.auth.util.JwtTokenProvider;
 import com.wootech.dropthecode.controller.auth.util.RedisUtil;
 import com.wootech.dropthecode.domain.Member;
+import com.wootech.dropthecode.domain.Role;
 import com.wootech.dropthecode.domain.Token;
 import com.wootech.dropthecode.domain.oauth.InMemoryProviderRepository;
 import com.wootech.dropthecode.domain.oauth.OauthAttributes;
@@ -74,6 +75,10 @@ public class OauthService {
                                         .map(entity -> entity.update(
                                                 userProfile.getEmail(), userProfile.getName(), userProfile.getImageUrl()))
                                         .orElseGet(userProfile::toMember);
+
+        if (member.hasRole(Role.DELETED)) {
+            member.setRole(Role.STUDENT);
+        }
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.profiles.include=oauth
-spring.profiles.active=pt-init
+spring.profiles.active=local
 
 spring.jpa.open-in-view=false
 


### PR DESCRIPTION
### 회원탈퇴 후 리뷰어 재등록 시 기존 정보를 업데이트하도록 수정
- 회원탈퇴한 유저가 로그인할 경우 Member 테이블의 유저 정보를 업데이트
- 회원탈퇴한 유저가 리뷰어로 등록할 경우 기존 TeacherProfile을 수정